### PR TITLE
Changed quality test interface

### DIFF
--- a/source/include/dqm4hep/QualityTest.h
+++ b/source/include/dqm4hep/QualityTest.h
@@ -83,7 +83,7 @@ namespace dqm4hep {
       std::string           m_monitorElementPath;
       std::string           m_message;
       float                 m_quality;
-      bool                  m_isSuccessful;
+      bool                  m_executed;
       Json::Value           m_extraInfos;
     };
 
@@ -195,10 +195,6 @@ namespace dqm4hep {
       /** Runs a quality test on the given monitor element
        */
       virtual StatusCode userRun(MonitorElementPtr monitorElement, QualityTestReport &report) = 0;
-
-      /** Whether the quality test can be run on the monitor element
-       */
-      virtual bool canRun(MonitorElementPtr monitorElement) const = 0;
 
       /** Fill basic info in the qtest report.
        *  Must be called at start of qtest run

--- a/source/include/dqm4hep/XmlHelper.h
+++ b/source/include/dqm4hep/XmlHelper.h
@@ -109,7 +109,7 @@ namespace dqm4hep {
        *  @param  t the parameter value to receive
        */
       template <typename T>
-      static StatusCode readParameterValue(const TiXmlHandle &xmlHandle, const std::string &parameterName, T &t);
+      static StatusCode readParameter(const TiXmlHandle &xmlHandle, const std::string &parameterName, T &t);
 
       /** 
        *  @brief  Read a parameter value from an xml element and use a predicate to validate the value
@@ -122,7 +122,7 @@ namespace dqm4hep {
        *  @param  validator a unary predicate to validate the parameter value
        */
       template <typename T, typename Validator>
-      static StatusCode readParameterValue(const TiXmlHandle &xmlHandle, const std::string &parameterName, T &t, Validator validator);
+      static StatusCode readParameter(const TiXmlHandle &xmlHandle, const std::string &parameterName, T &t, Validator validator);
 
       /** 
        *  @brief  Read a vector of values for a parameter from a (space separated) list in an xml element
@@ -134,7 +134,7 @@ namespace dqm4hep {
        *  @param  vector the parameter values to receive
        */
       template <typename T>
-      static StatusCode readParameterValues(const TiXmlHandle &xmlHandle, const std::string &parameterName, std::vector<T> &vector);
+      static StatusCode readParameters(const TiXmlHandle &xmlHandle, const std::string &parameterName, std::vector<T> &vector);
 
       /** 
        *  @brief  Read a vector of values for a parameter from a (space separated) list in an xml element
@@ -147,7 +147,7 @@ namespace dqm4hep {
        *  @param  validator a unary predicate to validate the parameter values
        */
       template <typename T, typename Validator>
-      static StatusCode readParameterValues(const TiXmlHandle &xmlHandle, const std::string &parameterName, std::vector<T> &vector, Validator validator);
+      static StatusCode readParameters(const TiXmlHandle &xmlHandle, const std::string &parameterName, std::vector<T> &vector, Validator validator);
     };
 
     //-------------------------------------------------------------------------------------------------
@@ -315,7 +315,7 @@ namespace dqm4hep {
     //-------------------------------------------------------------------------------------------------
 
     template <typename T>
-    inline StatusCode XmlHelper::readParameterValue(const TiXmlHandle &xmlHandle, const std::string &parameterName, T &t)
+    inline StatusCode XmlHelper::readParameter(const TiXmlHandle &xmlHandle, const std::string &parameterName, T &t)
     {
       for (TiXmlElement *pXmlElement = xmlHandle.FirstChild("parameter").Element(); NULL != pXmlElement;
           pXmlElement = pXmlElement->NextSiblingElement("parameter"))
@@ -343,9 +343,9 @@ namespace dqm4hep {
     //-------------------------------------------------------------------------------------------------
 
     template <typename T, typename Validator>
-    inline StatusCode XmlHelper::readParameterValue(const TiXmlHandle &xmlHandle, const std::string &parameterName, T &t, Validator validator)
+    inline StatusCode XmlHelper::readParameter(const TiXmlHandle &xmlHandle, const std::string &parameterName, T &t, Validator validator)
     {
-      RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::readParameterValue(xmlHandle, parameterName, t));
+      RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::readParameter(xmlHandle, parameterName, t));
 
       if( ! validator(t) )
         return STATUS_CODE_INVALID_PARAMETER;
@@ -356,7 +356,7 @@ namespace dqm4hep {
     //-------------------------------------------------------------------------------------------------
 
     template <typename T>
-    inline StatusCode XmlHelper::readParameterValues(const TiXmlHandle &xmlHandle, const std::string &parameterName, std::vector<T> &vector)
+    inline StatusCode XmlHelper::readParameters(const TiXmlHandle &xmlHandle, const std::string &parameterName, std::vector<T> &vector)
     {
       for (TiXmlElement *pXmlElement = xmlHandle.FirstChild("parameter").Element(); NULL != pXmlElement;
           pXmlElement = pXmlElement->NextSiblingElement("parameter"))
@@ -394,9 +394,9 @@ namespace dqm4hep {
     //-------------------------------------------------------------------------------------------------
 
     template <typename T, typename Validator>
-    inline StatusCode XmlHelper::readParameterValues(const TiXmlHandle &xmlHandle, const std::string &parameterName, std::vector<T> &vector, Validator validator)
+    inline StatusCode XmlHelper::readParameters(const TiXmlHandle &xmlHandle, const std::string &parameterName, std::vector<T> &vector, Validator validator)
     {
-      RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::readParameterValues(xmlHandle, parameterName, vector));
+      RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::readParameter(xmlHandle, parameterName, vector));
 
       if( ! validator(vector) )
         return STATUS_CODE_INVALID_PARAMETER;

--- a/source/include/dqm4hep/XmlHelper.h
+++ b/source/include/dqm4hep/XmlHelper.h
@@ -325,8 +325,13 @@ namespace dqm4hep {
 
         if(name != parameterName)
           continue;
+          
+        std::string value;
+        
+        if(STATUS_CODE_SUCCESS != XmlHelper::getAttribute(pXmlElement, "value", value))
+          value = pXmlElement->GetText() ? pXmlElement->GetText() : "";
 
-        if (!dqm4hep::core::stringToType(pXmlElement->GetText(), t))
+        if (!dqm4hep::core::stringToType(value, t))
           return STATUS_CODE_FAILURE;
 
         return STATUS_CODE_SUCCESS;
@@ -361,9 +366,14 @@ namespace dqm4hep {
 
         if(name != parameterName)
           continue;
+          
+        std::string value;
+        
+        if(STATUS_CODE_SUCCESS != XmlHelper::getAttribute(pXmlElement, "value", value))
+          value = pXmlElement->GetText() ? pXmlElement->GetText() : "";
 
         StringVector tokens;
-        dqm4hep::core::tokenize(pXmlElement->GetText(), tokens);
+        dqm4hep::core::tokenize(value, tokens);
 
         for (StringVector::const_iterator iter = tokens.begin(), iterEnd = tokens.end(); iter != iterEnd; ++iter)
         {

--- a/source/main/dqm4hep-run-qtests.cc
+++ b/source/main/dqm4hep-run-qtests.cc
@@ -327,7 +327,7 @@ int main(int argc, char* argv[])
       jsonQReports[jsonIndex] = jsonQReport;
       jsonIndex++;
 
-      if(!iter2.second.m_isSuccessful)
+      if(!iter2.second.m_executed)
       {
         std::cout << redBck << white << setw(40) << std::left << iter.first.second << setw(30) << std::left << iter2.second.m_qualityTestName << setw(10) << std::left << "FAIL" << setw(10) << std::left << "none" << iter2.second.m_message << reset << std::endl;
 

--- a/source/src/qtest/MeanWithinExpectedTest.cc
+++ b/source/src/qtest/MeanWithinExpectedTest.cc
@@ -90,15 +90,15 @@ namespace dqm4hep {
 
     StatusCode MeanWithinExpectedTest::readSettings(const TiXmlHandle xmlHandle)
     {
-      RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::readParameterValue(xmlHandle,
+      RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::readParameter(xmlHandle,
           "ExpectedMean", m_expectedMean));
 
-      RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::readParameterValue(xmlHandle,
+      RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::readParameter(xmlHandle,
           "MeanDeviationLower", m_meanDeviationLower, [this](const float &value){
             return value < this->m_expectedMean;
           }));
 
-      RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::readParameterValue(xmlHandle,
+      RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::readParameter(xmlHandle,
           "MeanDeviationUpper", m_meanDeviationUpper, [this](const float &value){
             return value > this->m_expectedMean;
           }));

--- a/tests/test_samples.xml
+++ b/tests/test_samples.xml
@@ -7,19 +7,19 @@
     <!-- MeanWithinExpectedTest qtests -->
     <qtests>
       <qtest type="MeanWithinExpectedTest" name="MeanAround10Long">
-        <ExpectedMean>10</ExpectedMean>
-        <MeanDeviationLower>8</MeanDeviationLower>
-        <MeanDeviationUpper>12</MeanDeviationUpper>
+        <parameter name="ExpectedMean" value="10"/>
+        <parameter name="MeanDeviationLower" value="8"/>
+        <parameter name="MeanDeviationUpper" value="12"/>
       </qtest>
       <qtest type="MeanWithinExpectedTest" name="MeanAround10Short">
-        <ExpectedMean>10</ExpectedMean>
-        <MeanDeviationLower>9.5</MeanDeviationLower>
-        <MeanDeviationUpper>10.5</MeanDeviationUpper>
+        <parameter name="ExpectedMean" value="10"/>
+        <parameter name="MeanDeviationLower" value="9.5"/>
+        <parameter name="MeanDeviationUpper" value="10.5"/>
       </qtest>
       <qtest type="MeanWithinExpectedTest" name="MeanAround15Short">
-        <ExpectedMean>15</ExpectedMean>
-        <MeanDeviationLower>14.5</MeanDeviationLower>
-        <MeanDeviationUpper>15.5</MeanDeviationUpper>
+        <parameter name="ExpectedMean" value="15"/>
+        <parameter name="MeanDeviationLower" value="14.5"/>
+        <parameter name="MeanDeviationUpper" value="15.5"/>
       </qtest>
     </qtests>
 


### PR DESCRIPTION
BEGINRELEASENOTES
- QualityTest class
   - Removed canRun() function
   - Sanity checks (e.g null ptr) are performed in base class before processing
   - Other specific checks are performed by qtests in the userRun() function
- QReport class
   - Renamed field m_isSuccessful to m_executed
- XmlHelper class
   - Renamed readParameterValue function to readParameter
- Updated MeanWithinExpectedTest

ENDRELEASENOTES