### PR TITLE
[WIP] Re-viewed quality test interface

### DIFF
--- a/cmake/quality-test-test.in
+++ b/cmake/quality-test-test.in
@@ -6,4 +6,4 @@ rootFile="test_samples.root"
 qTestFile="test_samples.xml"
 
 # the qtest runner
-@PROJECT_BINARY_DIR@/bin/dqm4hep-run-qtests --exit-on failure --quality-thresolds 0.7:0.9 --input-root-file ${rootFile} --input-qtest-file ${qTestFile}
+@PROJECT_BINARY_DIR@/bin/dqm4hep-run-qtests --exit-on failure --input-root-file ${rootFile} --input-qtest-file ${qTestFile}

--- a/source/include/dqm4hep/MonitorElementManager.h
+++ b/source/include/dqm4hep/MonitorElementManager.h
@@ -224,6 +224,15 @@ namespace dqm4hep {
        * @param  fileName        the root file name contaning the reference
        */
       StatusCode attachReference(MonitorElementPtr monitorElement, const std::string &fileName);
+      
+      /**
+       *  @brief  Read monitor element described by the xml element from a root file
+       *
+       *  @param  pTFile the root file
+       *  @param  pXmlElement the xml element describing the objects to read
+       *  @param  readQTests whether to associate qtest to monitor elements
+       */
+      StatusCode readMonitorElements(TFile *pTFile, TiXmlElement *const pXmlElement, bool readQTests = true);
 
     public:
       ///////////////////////
@@ -256,10 +265,14 @@ namespace dqm4hep {
       // QUALITY TEST INTERFACE //
       ////////////////////////////
 
+      /** Create quality tests from the xml element.
+       */
+      StatusCode createQualityTests(TiXmlElement *const pXmlElement);      
+      
       /** Create a quality test from the xml element.
        *  The xml element must contain the attribute 'type' and 'name'
        */
-      StatusCode createQualityTest(TiXmlElement *const pXmlElement);
+      StatusCode createQualityTest(TiXmlElement *const pXmlElement, float warning = QualityTest::defaultWarningLimit(), float error = QualityTest::defaultErrorLimit());
 
       /** Add a (already created) quality test to the monitor element
        */

--- a/source/include/dqm4hep/MonitorElementManager.h
+++ b/source/include/dqm4hep/MonitorElementManager.h
@@ -233,6 +233,13 @@ namespace dqm4hep {
        *  @param  readQTests whether to associate qtest to monitor elements
        */
       StatusCode readMonitorElements(TFile *pTFile, TiXmlElement *const pXmlElement, bool readQTests = true);
+      
+      /**
+       *  @brief  Write all monitor elements in the storage to json
+       *  
+       *  @param  object the json object to receive
+       */
+      void monitorElementsToJson(json &object) const;
 
     public:
       ///////////////////////

--- a/source/include/dqm4hep/QualityTest.h
+++ b/source/include/dqm4hep/QualityTest.h
@@ -153,6 +153,13 @@ namespace dqm4hep {
       /** Clear all contents
        */
       void clear();
+      
+      /**
+       *  @brief  Write contents to a json file
+       *  
+       *  @param  fname the file name
+       */
+      void write(const std::string &fname);
 
     private:
       QReportContainer m_reports;
@@ -222,14 +229,6 @@ namespace dqm4hep {
        *  @brief  Get the error limit
        */
       float errorLimit() const;
-
-      /**
-       *  @brief  Set the default warning and error limits
-       *  
-       *  @param  warning the warning limit
-       *  @param  error the error limit
-       */
-      static void setDefaultLimits(float warning, float error);
       
       /**
        *  @brief  Get the default warning limit  

--- a/source/include/dqm4hep/QualityTest.h
+++ b/source/include/dqm4hep/QualityTest.h
@@ -155,11 +155,11 @@ namespace dqm4hep {
       void clear();
       
       /**
-       *  @brief  Write contents to a json file
+       *  @brief  Convert all stored reports to json format
        *  
-       *  @param  fname the file name
+       *  @param  object the json object to receive
        */
-      void write(const std::string &fname);
+      void toJson(json &object) const;
 
     private:
       QReportContainer m_reports;

--- a/source/include/dqm4hep/QualityTest.h
+++ b/source/include/dqm4hep/QualityTest.h
@@ -223,6 +223,24 @@ namespace dqm4hep {
        */
       float errorLimit() const;
 
+      /**
+       *  @brief  Set the default warning and error limits
+       *  
+       *  @param  warning the warning limit
+       *  @param  error the error limit
+       */
+      static void setDefaultLimits(float warning, float error);
+      
+      /**
+       *  @brief  Get the default warning limit  
+       */
+      static float defaultWarningLimit();
+      
+      /**
+       *  @brief  Get the default error limit  
+       */
+      static float defaultErrorLimit();
+
     protected:
       /** Runs a quality test on the given monitor element and return a quality estimate
        */
@@ -241,10 +259,8 @@ namespace dqm4hep {
 
     protected:
       std::string m_description; ///< Quality test description
-
-    public:
-      static constexpr float defaultWarningLimit = {0.8};
-      static constexpr float defaultErrorLimit = {0.5};
+      static float m_defaultWarningLimit;
+      static float m_defaultErrorLimit;
     };
 
     //-------------------------------------------------------------------------------------------------

--- a/source/include/dqm4hep/QualityTest.h
+++ b/source/include/dqm4hep/QualityTest.h
@@ -40,6 +40,15 @@ namespace dqm4hep {
   namespace core {
 
     class TiXmlHandle;
+    
+    enum QualityFlag {
+      UNDEFINED,
+      INVALID,
+      INSUFFICENT_STAT,
+      SUCCESS,
+      WARNING,
+      ERROR
+    };
 
     /** QualityTestReport class
      *  Hanlde the result of a quality test
@@ -78,8 +87,8 @@ namespace dqm4hep {
       std::string m_monitorElementType;
       std::string m_monitorElementPath;
       std::string m_message;
+      QualityFlag m_qualityFlag;
       float m_quality;
-      bool m_executed;
       json m_extraInfos;
     };
 
@@ -187,6 +196,13 @@ namespace dqm4hep {
       /** Initialize the quality test.
        */
       virtual StatusCode init();
+      
+      /**
+       *  @brief  Whether the monitor element has enough statistics to perform the qtest
+       *
+       *  @param  monitorElement the monitor element to check
+       */
+      virtual bool enoughStatistics(MonitorElementPtr monitorElement) const;
 
       /**
        *  @brief  Set the warning and error limits on quality test result.
@@ -208,9 +224,9 @@ namespace dqm4hep {
       float errorLimit() const;
 
     protected:
-      /** Runs a quality test on the given monitor element
+      /** Runs a quality test on the given monitor element and return a quality estimate
        */
-      virtual StatusCode userRun(MonitorElementPtr monitorElement, QualityTestReport &report) = 0;
+      virtual void userRun(MonitorElementPtr monitorElement, QualityTestReport &report) = 0;
 
       /** Fill basic info in the qtest report.
        *  Must be called at start of qtest run
@@ -252,6 +268,12 @@ namespace dqm4hep {
 
     inline StatusCode QualityTest::init() {
       return STATUS_CODE_SUCCESS;
+    }
+    
+    //-------------------------------------------------------------------------------------------------
+    
+    inline bool QualityTest::enoughStatistics(MonitorElementPtr /*monitorElement*/) const {
+      return true;
     }
 
     //-------------------------------------------------------------------------------------------------

--- a/source/include/dqm4hep/QualityTest.h
+++ b/source/include/dqm4hep/QualityTest.h
@@ -188,6 +188,25 @@ namespace dqm4hep {
        */
       virtual StatusCode init();
 
+      /**
+       *  @brief  Set the warning and error limits on quality test result.
+       *          The limits must be ordered as 0 < error < warning < 1, else throws an exception
+       *
+       *  @param  warning the warning limit
+       *  @param  error the error limit
+       */
+      void setLimits(float warning, float error);
+
+      /**
+       *  @brief  Get the warning limit
+       */
+      float warningLimit() const;
+
+      /**
+       *  @brief  Get the error limit
+       */
+      float errorLimit() const;
+
     protected:
       /** Runs a quality test on the given monitor element
        */
@@ -199,11 +218,17 @@ namespace dqm4hep {
       void fillBasicInfo(MonitorElementPtr monitorElement, QualityTestReport &report) const;
 
     private:
-      std::string m_type; ///< Quality test type (usually class name)
-      std::string m_name; ///< Quality test name
+      std::string m_type = {""};  ///< Quality test type (usually class name)
+      std::string m_name = {""};  ///< Quality test name
+      float m_warningLimit = {0}; ///< The quality test warning threshold
+      float m_errorLimit = {0};   ///< The quality test error threshold
 
     protected:
       std::string m_description; ///< Quality test description
+
+    public:
+      static constexpr float defaultWarningLimit = {0.8};
+      static constexpr float defaultErrorLimit = {0.5};
     };
 
     //-------------------------------------------------------------------------------------------------

--- a/source/include/dqm4hep/XmlHelper.h
+++ b/source/include/dqm4hep/XmlHelper.h
@@ -280,7 +280,10 @@ namespace dqm4hep {
     template <typename T, typename Validator>
     inline StatusCode XmlHelper::getAttribute(const TiXmlElement *const pXmlElement, const std::string &attributeName,
                                               T &attributeValue, Validator validator) {
-      RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::getAttribute<T>(pXmlElement, attributeName, attributeValue));
+      const StatusCode statusCode(XmlHelper::getAttribute<T>(pXmlElement, attributeName, attributeValue));
+      
+      if(STATUS_CODE_SUCCESS != statusCode)
+        return statusCode;
 
       if (!validator(attributeValue))
         return STATUS_CODE_INVALID_PARAMETER;
@@ -337,7 +340,10 @@ namespace dqm4hep {
     template <typename T, typename Validator>
     inline StatusCode XmlHelper::readParameter(const TiXmlHandle &xmlHandle, const std::string &parameterName, T &t,
                                                Validator validator) {
-      RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::readParameter(xmlHandle, parameterName, t));
+     const StatusCode statusCode(XmlHelper::readParameter(xmlHandle, parameterName, t));
+     
+     if(STATUS_CODE_SUCCESS != statusCode)
+       return statusCode;
 
       if (!validator(t))
         return STATUS_CODE_INVALID_PARAMETER;
@@ -386,7 +392,11 @@ namespace dqm4hep {
     template <typename T, typename Validator>
     inline StatusCode XmlHelper::readParameters(const TiXmlHandle &xmlHandle, const std::string &parameterName,
                                                 std::vector<T> &vector, Validator validator) {
-      RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::readParameter(xmlHandle, parameterName, vector));
+      
+      const StatusCode statusCode(XmlHelper::readParameter(xmlHandle, parameterName, vector));
+      
+      if(STATUS_CODE_SUCCESS != statusCode)
+        return statusCode;
 
       if (!validator(vector))
         return STATUS_CODE_INVALID_PARAMETER;

--- a/source/src/MonitorElementManager.cc
+++ b/source/src/MonitorElementManager.cc
@@ -364,6 +364,14 @@ namespace dqm4hep {
       std::string name, type;
       RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::getAttribute(pXmlElement, "name", name));
       RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::getAttribute(pXmlElement, "type", type));
+      
+      float warningLimit(QualityTest::defaultWarningLimit), errorLimit(QualityTest::defaultWarningLimit);
+      RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::getAttribute(pXmlElement, "error", errorLimit, [](const float &value){
+        return (value >= 0.f && value < 1.f);
+      }));
+      RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::getAttribute(pXmlElement, "warning", warningLimit, [&errorLimit](const float &value){
+        return (value >=0.f && value > errorLimit && value <= 1.f);
+      }));
 
       auto findIter = m_qualityTestMap.find(name);
 
@@ -377,6 +385,7 @@ namespace dqm4hep {
 
       QualityTestPtr qualityTest = findFactoryIter->second->createQualityTest(name);
 
+      qualityTest->setLimits(warningLimit, errorLimit);
       RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, qualityTest->readSettings(TiXmlHandle(pXmlElement)));
       RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, qualityTest->init());
 

--- a/source/src/MonitorElementManager.cc
+++ b/source/src/MonitorElementManager.cc
@@ -352,6 +352,17 @@ namespace dqm4hep {
       
       return STATUS_CODE_SUCCESS;
     }
+    
+    //-------------------------------------------------------------------------------------------------
+    
+    void MonitorElementManager::monitorElementsToJson(json &object) const {
+      m_storage.iterate([&object](const MonitorElementDir &, MonitorElementPtr monitorElement) {
+        json meObject;
+        monitorElement->toJson(meObject);
+        object.push_back(meObject);
+        return true;
+      });
+    }
 
     //-------------------------------------------------------------------------------------------------
     //-------------------------------------------------------------------------------------------------

--- a/source/src/QualityTest.cc
+++ b/source/src/QualityTest.cc
@@ -283,12 +283,17 @@ namespace dqm4hep {
     //-------------------------------------------------------------------------------------------------
     //-------------------------------------------------------------------------------------------------
 
+    float QualityTest::m_defaultWarningLimit = 0.8;
+    float QualityTest::m_defaultErrorLimit = 0.5;
+    
+    //-------------------------------------------------------------------------------------------------
+
     QualityTest::QualityTest(const std::string &type, const std::string &name)
         : m_type(type),
           m_name(name),
           m_description(""),
-          m_warningLimit(defaultWarningLimit),
-          m_errorLimit(defaultErrorLimit) {
+          m_warningLimit(m_defaultWarningLimit),
+          m_errorLimit(m_defaultErrorLimit) {
       /* nop */
     }
 
@@ -384,6 +389,7 @@ namespace dqm4hep {
     //-------------------------------------------------------------------------------------------------
 
     void QualityTest::setLimits(float warning, float error) {
+      
       if (warning < 0.f || error > 1.f || warning < error) {
         dqm_error("QualityTest::setLimits: Wrong limits provided (warning = {0}, error = {1})!", warning, error);
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
@@ -403,6 +409,31 @@ namespace dqm4hep {
 
     float QualityTest::errorLimit() const {
       return m_errorLimit;
+    }
+    
+    //-------------------------------------------------------------------------------------------------
+    
+    void QualityTest::setDefaultLimits(float warning, float error) {
+      
+      if (warning < 0.f || error > 1.f || warning < error) {
+        dqm_error("QualityTest::setDefaultLimits: Wrong limits provided (warning = {0}, error = {1})!", warning, error);
+        throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+      }
+
+      QualityTest::m_defaultWarningLimit = warning;
+      QualityTest::m_defaultErrorLimit = error;
+    }
+    
+    //-------------------------------------------------------------------------------------------------
+    
+    float QualityTest::defaultWarningLimit() {
+      return m_defaultWarningLimit;
+    }
+    
+    //-------------------------------------------------------------------------------------------------
+    
+    float QualityTest::defaultErrorLimit() {
+      return m_defaultErrorLimit;
     }
 
     //-------------------------------------------------------------------------------------------------

--- a/source/src/QualityTest.cc
+++ b/source/src/QualityTest.cc
@@ -282,32 +282,14 @@ namespace dqm4hep {
     
     //-------------------------------------------------------------------------------------------------
     
-    void QReportStorage::write(const std::string &fname) {
-      
-      json jsonRoot, jsonMetadata, jsonQReports;
-      std::string date;
-      timeToHMS(time(nullptr), date);
-      StringMap hostInfos;
-      fillHostInfo(hostInfos);
-
-      jsonMetadata["host"] = hostInfos;
-      jsonMetadata["date"] = date;
-      jsonRoot["meta"] = jsonMetadata;
-      
+    void QReportStorage::toJson(json &object) const {      
       for (const auto &iter : m_reports) {
         for (const auto &iter2 : iter.second) {
           json jsonQReport;
           iter2.second.toJson(jsonQReport);
-          jsonQReports.push_back(jsonQReport);
+          object.push_back(jsonQReport);
         }
       }
-      
-      jsonRoot["qreports"] = jsonQReports;
-        
-      std::ofstream jsonFile;
-      jsonFile.open(fname.c_str());
-      jsonFile << jsonRoot.dump(2);
-      jsonFile.close();
     }
 
     //-------------------------------------------------------------------------------------------------

--- a/source/src/QualityTest.cc
+++ b/source/src/QualityTest.cc
@@ -279,6 +279,36 @@ namespace dqm4hep {
     void QReportStorage::clear() {
       m_reports.clear();
     }
+    
+    //-------------------------------------------------------------------------------------------------
+    
+    void QReportStorage::write(const std::string &fname) {
+      
+      json jsonRoot, jsonMetadata, jsonQReports;
+      std::string date;
+      timeToHMS(time(nullptr), date);
+      StringMap hostInfos;
+      fillHostInfo(hostInfos);
+
+      jsonMetadata["host"] = hostInfos;
+      jsonMetadata["date"] = date;
+      jsonRoot["meta"] = jsonMetadata;
+      
+      for (const auto &iter : m_reports) {
+        for (const auto &iter2 : iter.second) {
+          json jsonQReport;
+          iter2.second.toJson(jsonQReport);
+          jsonQReports.push_back(jsonQReport);
+        }
+      }
+      
+      jsonRoot["qreports"] = jsonQReports;
+        
+      std::ofstream jsonFile;
+      jsonFile.open(fname.c_str());
+      jsonFile << jsonRoot.dump(2);
+      jsonFile.close();
+    }
 
     //-------------------------------------------------------------------------------------------------
     //-------------------------------------------------------------------------------------------------
@@ -409,19 +439,6 @@ namespace dqm4hep {
 
     float QualityTest::errorLimit() const {
       return m_errorLimit;
-    }
-    
-    //-------------------------------------------------------------------------------------------------
-    
-    void QualityTest::setDefaultLimits(float warning, float error) {
-      
-      if (warning < 0.f || error > 1.f || warning < error) {
-        dqm_error("QualityTest::setDefaultLimits: Wrong limits provided (warning = {0}, error = {1})!", warning, error);
-        throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
-      }
-
-      QualityTest::m_defaultWarningLimit = warning;
-      QualityTest::m_defaultErrorLimit = error;
     }
     
     //-------------------------------------------------------------------------------------------------

--- a/source/src/QualityTest.cc
+++ b/source/src/QualityTest.cc
@@ -284,7 +284,11 @@ namespace dqm4hep {
     //-------------------------------------------------------------------------------------------------
 
     QualityTest::QualityTest(const std::string &type, const std::string &name)
-        : m_type(type), m_name(name), m_description("") {
+        : m_type(type),
+          m_name(name),
+          m_description(""),
+          m_warningLimit(defaultWarningLimit),
+          m_errorLimit(defaultErrorLimit) {
       /* nop */
     }
 
@@ -355,6 +359,30 @@ namespace dqm4hep {
         report.m_quality = 0.f;
         report.m_executed = false;
       }
+    }
+
+    //-------------------------------------------------------------------------------------------------
+
+    void QualityTest::setLimits(float warning, float error) {
+      if (warning < 0.f || error > 1.f || warning < error) {
+        dqm_error("QualityTest::setLimits: Wrong limits provided (warning = {0}, error = {1})!", warning, error);
+        throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+      }
+
+      m_warningLimit = warning;
+      m_errorLimit = error;
+    }
+
+    //-------------------------------------------------------------------------------------------------
+
+    float QualityTest::warningLimit() const {
+      return m_warningLimit;
+    }
+
+    //-------------------------------------------------------------------------------------------------
+
+    float QualityTest::errorLimit() const {
+      return m_errorLimit;
     }
 
     //-------------------------------------------------------------------------------------------------

--- a/source/src/qtest/MeanWithinExpectedTest.cc
+++ b/source/src/qtest/MeanWithinExpectedTest.cc
@@ -54,7 +54,7 @@ namespace dqm4hep {
       MeanWithinExpectedTest(const std::string &name);
       ~MeanWithinExpectedTest() override = default;
       StatusCode readSettings(const dqm4hep::core::TiXmlHandle xmlHandle) override;
-      StatusCode userRun(MonitorElementPtr monitorElement, QualityTestReport &report) override;
+      void userRun(MonitorElementPtr monitorElement, QualityTestReport &report) override;
 
     protected:
       float m_expectedMean;
@@ -102,12 +102,12 @@ namespace dqm4hep {
 
     //-------------------------------------------------------------------------------------------------
 
-    StatusCode MeanWithinExpectedTest::userRun(MonitorElementPtr monitorElement, QualityTestReport &report) {
+    void MeanWithinExpectedTest::userRun(MonitorElementPtr monitorElement, QualityTestReport &report) {
       TH1 *pHistogram = monitorElement->objectTo<TH1>();
 
       if (nullptr == pHistogram) {
         report.m_message = "ROOT monitor object is not a TH1 object !";
-        return STATUS_CODE_INVALID_PTR;
+        throw StatusCodeException(STATUS_CODE_INVALID_PTR);
       }
 
       const float mean(pHistogram->GetMean());
@@ -116,16 +116,14 @@ namespace dqm4hep {
       if (m_meanDeviationLower < mean && mean < m_meanDeviationUpper) {
         report.m_message =
             "Within expected range: expected " + typeToString(m_expectedMean) + ", got " + typeToString(mean);
-      } else {
+      } 
+      else {
         report.m_message =
             "Out of expected range: expected " + typeToString(m_expectedMean) + ", got " + typeToString(mean);
       }
 
       const float chi = (mean - m_expectedMean) / range;
-      const float probability = TMath::Prob(chi * chi, 1);
-      report.m_quality = probability;
-
-      return STATUS_CODE_SUCCESS;
+      report.m_quality = TMath::Prob(chi * chi, 1);
     }
 
     DQM_PLUGIN_DECL(MeanWithinExpectedTestFactory, "MeanWithinExpectedTest");

--- a/tests/test_samples.xml
+++ b/tests/test_samples.xml
@@ -6,7 +6,7 @@
 
     <!-- MeanWithinExpectedTest qtests -->
     <qtests>
-      <qtest type="MeanWithinExpectedTest" name="MeanAround10Long">
+      <qtest type="MeanWithinExpectedTest" name="MeanAround10Long" error="0.3" warning="0.9">
         <parameter name="ExpectedMean" value="10"/>
         <parameter name="MeanDeviationLower" value="8"/>
         <parameter name="MeanDeviationUpper" value="12"/>


### PR DESCRIPTION

BEGINRELEASENOTES
- QualityTest class
    - Added warning and error limits
    - Added QualityFlag enum as main evaluator of qtest (goes in the report)
- MonitorElement class
    - Added serialisation to json object
- MonitorElementManager class
    - Can read warning/error limits as global or local values for all/single qtest from XML
    - Can write all monitor elements from storage to json
- QReportStorage class
    - Can write all reports to json
- QTest runner
    - Refactored into separate class method to clarify workflow
    - Added possibility to write monitor elements in final QReport
    - Added possibility to compress/beautify json in QReport output file
- Updated quality test unit test

ENDRELEASENOTES