### PR TITLE
Mem stats Implementation on OSX

### DIFF
--- a/source/include/dqm4hep/Internal.h
+++ b/source/include/dqm4hep/Internal.h
@@ -51,7 +51,6 @@
 
 #include <sys/stat.h>
 #include <sys/utsname.h>
-#include <sys/sysinfo.h>
 #include <thread>
 #include <unistd.h>
 
@@ -67,6 +66,7 @@
 #include <sys/_types/_int16_t.h>
 #include <sys/_types/_int64_t.h>
 #else
+#include <sys/sysinfo.h>
 #include <bits/pthreadtypes.h>
 #include <stdint.h>
 #endif

--- a/source/include/dqm4hep/Internal.h
+++ b/source/include/dqm4hep/Internal.h
@@ -65,6 +65,9 @@
 #include <sys/_pthread/_pthread_types.h>
 #include <sys/_types/_int16_t.h>
 #include <sys/_types/_int64_t.h>
+// for memStats
+#include <sys/sysctl.h>
+#include <mach/mach.h>
 #else
 #include <sys/sysinfo.h>
 #include <bits/pthreadtypes.h>


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix compilation on OSX: `sysinfo.h` header doesn't exist on OSX  
- Implements memory stat on OSX  [WIP]

ENDRELEASENOTES

Some context on the apple way of managing memory, more information available on the apple developer [documentation](https://developer.apple.com/library/content/documentation/Performance/Conceptual/ManagingMemory/Articles/AboutMemory.html) :
 - `Swap`: It's allocated dynamically and increases as the system needs it until there is no more room on the boot disk : I still count the allocated swap in the total `Virtual Memory` allocated.
 - Total Memory:
   - `Wired Memory`: Physical Memory in use that cannot go to swap
   - `Active Memory`: Physical Memory in use that can go inactive if not accessed for some time (`App Memory` in Activity Monitor)
   - `Inactive Memory`: Physical Memory that might go to swap if needed (`Cached Memory` in the Activity Monitor)
   - `Free Memory`: Truly free ram that can be allocated to a process without needing to swap
   - On top of the `active/inactive/wired` memory there is the `Compressed Memory`, that is part of the Physical Memory (not in the swap) compressed to make more room for other processes. I didn't find a way to access its value that can actually be quite extensive (~2Gb currently on my 8Gb RAM mac for instance).  
- Process Memory:
   - `Physical Memory`: corresponds to the real memory foot print (as can be found in `real mem` of the Activity Monitor).
   - `Virtual Memory`: Does not have the same meaning as on unix. Every process seems to have around 4GB (on my mac) of `VM` allocated. I guess we could display the `Physical Memory` here too, so the readings make sense. 

