### PR TITLE
Coverity scan fix

### DIFF
--- a/source/include/dqm4hep/Archiver.h
+++ b/source/include/dqm4hep/Archiver.h
@@ -52,7 +52,7 @@ namespace dqm4hep {
     public:
       /** Constructor
        */
-      Archiver();
+      Archiver() = default;
 
       /** Constructor with file name and opening mode
        */
@@ -61,7 +61,7 @@ namespace dqm4hep {
 
       /** Destructor
        */
-      virtual ~Archiver();
+      ~Archiver();
 
       /** Open a new archive.
        *  Close the current file if opened. Supported opening mode are the TFile opening mode option (see TFile)
@@ -104,10 +104,10 @@ namespace dqm4hep {
 
     private:
       // members
-      std::string m_fileName;    ///< The root file name
-      std::string m_openingMode; ///< The root file opening mode
-      bool m_isOpened;           ///< Whether the archive is opened
-      TFile *m_pArchiveFile;     ///< The actual archive implementation (root file)
+      std::string    m_fileName = {""};              ///< The root file name
+      std::string    m_openingMode = {"RECREATE"};   ///< The root file opening mode
+      bool           m_isOpened = {false};           ///< Whether the archive is opened
+      TFile         *m_pArchiveFile = {nullptr};     ///< The actual archive implementation (root file)
     };
   }
 }

--- a/source/include/dqm4hep/Internal.h
+++ b/source/include/dqm4hep/Internal.h
@@ -91,6 +91,9 @@
 #define IS_INF std::isinf
 #endif
 
+// Useful macro to silent any exception
+#define DQM4HEP_NO_EXCEPTION( Code ) try { Code } catch(...) {}
+
 namespace dqm4hep {
 
   namespace core {

--- a/source/include/dqm4hep/PluginManager.h
+++ b/source/include/dqm4hep/PluginManager.h
@@ -124,7 +124,8 @@ namespace dqm4hep {
       StatusCode registerPlugin(Plugin *pPlugin);
 
     private:
-      PluginMap m_pluginMap;
+      PluginMap               m_pluginMap;       ///< The map of registered plugins
+      std::vector<void*>      m_dlLibraries;     ///< The list of loaded libraries
     };
 
     //-------------------------------------------------------------------------------------------------

--- a/source/include/dqm4hep/StatusCodes.h
+++ b/source/include/dqm4hep/StatusCodes.h
@@ -40,7 +40,7 @@
   {                                                                                                                    \
     const dqm4hep::core::StatusCode statusCode(Command);                                                               \
     if (statusCode Operator StatusCode1) {                                                                             \
-      dqm_error("{0} return {1}, ", #Command, dqm4hep::core::statusCodeToString(statusCode));                          \
+      DQM4HEP_NO_EXCEPTION( dqm_error("{0} return {1}, ", #Command, dqm4hep::core::statusCodeToString(statusCode)); ); \
       dqm_error("    in function: {0}", __FUNCTION__);                                                                 \
       dqm_error("    in file:     {0} line#: {1}", __FILE__, __LINE__);                                                \
       return statusCode;                                                                                               \
@@ -53,7 +53,7 @@
   {                                                                                                                    \
     const dqm4hep::core::StatusCode statusCode(Command);                                                               \
     if ((statusCode Operator StatusCode1) && (statusCode Operator StatusCode2)) {                                      \
-      dqm_error("{0} return {1}, ", #Command, dqm4hep::core::statusCodeToString(statusCode));                          \
+      DQM4HEP_NO_EXCEPTION( dqm_error("{0} return {1}, ", #Command, dqm4hep::core::statusCodeToString(statusCode)); ); \
       dqm_error("    in function: {0}", __FUNCTION__);                                                                 \
       dqm_error("    in file:     {0} line#: {1}", __FILE__, __LINE__);                                                \
       return statusCode;                                                                                               \
@@ -66,7 +66,7 @@
   {                                                                                                                    \
     const dqm4hep::core::StatusCode statusCode(Command);                                                               \
     if (statusCode Operator StatusCode1) {                                                                             \
-      dqm_error("{0} return {1}, ", #Command, dqm4hep::core::statusCodeToString(statusCode));                          \
+      DQM4HEP_NO_EXCEPTION( dqm_error("{0} return {1}, ", #Command, dqm4hep::core::statusCodeToString(statusCode)); ); \
       dqm_error("    in function: {0}", __FUNCTION__);                                                                 \
       dqm_error("    in file:     {0} line#: {1}", __FILE__, __LINE__);                                                \
       throw dqm4hep::core::StatusCodeException(statusCode);                                                            \
@@ -79,7 +79,7 @@
   {                                                                                                                    \
     const dqm4hep::core::StatusCode statusCode(Command);                                                               \
     if ((statusCode Operator StatusCode1) && (statusCode Operator StatusCode2)) {                                      \
-      dqm_error("{0} return {1}, ", #Command, dqm4hep::core::statusCodeToString(statusCode));                          \
+      DQM4HEP_NO_EXCEPTION( dqm_error("{0} return {1}, ", #Command, dqm4hep::core::statusCodeToString(statusCode)); ); \
       dqm_error("    in function: {0}", __FUNCTION__);                                                                 \
       dqm_error("    in file:     {0} line#: {1}", __FILE__, __LINE__);                                                \
       throw dqm4hep::core::StatusCodeException(statusCode);                                                            \

--- a/source/main/dqm4hep-dump-plugins.cc
+++ b/source/main/dqm4hep-dump-plugins.cc
@@ -42,7 +42,7 @@ int main(int argc, char *argv[]) {
     THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PluginManager::instance()->loadLibraries());
     PluginManager::instance()->dump();
   } catch (StatusCodeException &e) {
-    dqm_error("While loading libraries : Caught {0}", e.toString());
+    DQM4HEP_NO_EXCEPTION( dqm_error("While loading libraries : Caught {0}", e.toString()); );
     return e.getStatusCode();
   } catch (...) {
     dqm_error("While loading libraries : Caught unknown error");

--- a/source/main/dqm4hep-dump-plugins.cc
+++ b/source/main/dqm4hep-dump-plugins.cc
@@ -38,16 +38,22 @@ using namespace std;
 using namespace dqm4hep::core;
 
 int main(int argc, char *argv[]) {
+  
   try {
     THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PluginManager::instance()->loadLibraries());
     PluginManager::instance()->dump();
-  } catch (StatusCodeException &e) {
+    PluginManager::kill();
+  } 
+  catch (StatusCodeException &e) {
     DQM4HEP_NO_EXCEPTION( dqm_error("While loading libraries : Caught {0}", e.toString()); );
+    PluginManager::kill();
     return e.getStatusCode();
-  } catch (...) {
+  } 
+  catch (...) {
     dqm_error("While loading libraries : Caught unknown error");
+    PluginManager::kill();
     return 1;
   }
-
+  
   return 0;
 }

--- a/source/main/dqm4hep-mysql-create-db.cc
+++ b/source/main/dqm4hep-mysql-create-db.cc
@@ -70,7 +70,7 @@ int main(int argc, char *argv[]) {
   try {
     THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, interface.connect(dbHostArg.getValue(), "root", password, ""));
   } catch (StatusCodeException &exception) {
-    dqm_error("MySQL error, couldn't connect to host '{0}' as root: {1}", dbHostArg.getValue(), exception.toString());
+    DQM4HEP_NO_EXCEPTION( dqm_error("MySQL error, couldn't connect to host '{0}' as root: {1}", dbHostArg.getValue(), exception.toString()); );
     return 1;
   }
 
@@ -79,7 +79,7 @@ int main(int argc, char *argv[]) {
     query << "CREATE DATABASE IF NOT EXISTS " << dbDbArg.getValue() << " ;";
     THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, interface.execute(query.str()));
   } catch (StatusCodeException &exception) {
-    dqm_error("MySQL error, couldn't create database '{0}': {1}", dbDbArg.getValue(), exception.toString());
+    DQM4HEP_NO_EXCEPTION( dqm_error("MySQL error, couldn't create database '{0}': {1}", dbDbArg.getValue(), exception.toString()); );
     return 1;
   }
 

--- a/source/main/dqm4hep-mysql-dump-parameters.cc
+++ b/source/main/dqm4hep-mysql-dump-parameters.cc
@@ -76,7 +76,7 @@ int main(int argc, char *argv[]) {
                     interface.connect(dbHostArg.getValue(), "DQM4HEP", "", dbDbArg.getValue()));
     THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, interface.dumpParameterTable(dbTableArg.getValue()));
   } catch (StatusCodeException &exception) {
-    dqm_error("MySQL error, couldn't dump parameters from table: {0}", exception.toString());
+    DQM4HEP_NO_EXCEPTION( dqm_error("MySQL error, couldn't dump parameters from table: {0}", exception.toString()); );
     return 1;
   }
 

--- a/source/main/dqm4hep-mysql-push-parameters.cc
+++ b/source/main/dqm4hep-mysql-push-parameters.cc
@@ -177,7 +177,7 @@ int main(int argc, char *argv[]) {
                       findIter->second.m_dbInterface->createParameterTable(dbTable, true, false));
       THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, findIter->second.m_dbInterface->setParameters(dbTable, parameterMap));
     } catch (StatusCodeException &exception) {
-      dqm_error("MySQL error, couldn't push parameters into table: {0}", exception.toString());
+      DQM4HEP_NO_EXCEPTION( dqm_error("MySQL error, couldn't push parameters into table: {0}", exception.toString()); );
       return 1;
     }
 

--- a/source/main/dqm4hep-mysql-rm-user.cc
+++ b/source/main/dqm4hep-mysql-rm-user.cc
@@ -78,7 +78,7 @@ int main(int argc, char *argv[]) {
   try {
     THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, interface.connect(dbHostArg.getValue(), "root", rootPassword, ""));
   } catch (StatusCodeException &exception) {
-    dqm_error("MySQL error, couldn't connect to host '{0}' as root: {1}", dbHostArg.getValue(), exception.toString());
+    DQM4HEP_NO_EXCEPTION( dqm_error("MySQL error, couldn't connect to host '{0}' as root: {1}", dbHostArg.getValue(), exception.toString()); );
     return 1;
   }
 

--- a/source/main/dqm4hep-mysql-set-parameter.cc
+++ b/source/main/dqm4hep-mysql-set-parameter.cc
@@ -98,7 +98,7 @@ int main(int argc, char *argv[]) {
     THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, interface.createParameterTable(dbTableArg.getValue(), true, false));
     THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, interface.setParameters(dbTableArg.getValue(), parameters));
   } catch (StatusCodeException &exception) {
-    dqm_error("MySQL error, couldn't set parameter into table: {0}", exception.toString());
+    DQM4HEP_NO_EXCEPTION( dqm_error("MySQL error, couldn't set parameter into table: {0}", exception.toString()); );
     return 1;
   }
 

--- a/source/main/dqm4hep-run-qtests.cc
+++ b/source/main/dqm4hep-run-qtests.cc
@@ -287,12 +287,16 @@ int main(int argc, char *argv[]) {
   }
   catch (StatusCodeException &e) {
     DQM4HEP_NO_EXCEPTION( dqm_error("Caught status code exception: {0}", e.toString()); );
+    PluginManager::kill();
     return e.getStatusCode();
   } 
   catch (...) {
     dqm_error("Caught unknown exception ...");
+    PluginManager::kill();
     return 1;
   }
+  
+  PluginManager::kill();
 
   if (returnFailure) {
     dqm_warning("Option --return-on {0} was given => return -1 !", qualityExitArg.getValue());

--- a/source/main/dqm4hep-run-qtests.cc
+++ b/source/main/dqm4hep-run-qtests.cc
@@ -286,7 +286,7 @@ int main(int argc, char *argv[]) {
     }
   }
   catch (StatusCodeException &e) {
-    dqm_error("Caught status code exception: {0}", e.toString());
+    DQM4HEP_NO_EXCEPTION( dqm_error("Caught status code exception: {0}", e.toString()); );
     return e.getStatusCode();
   } 
   catch (...) {

--- a/source/src/Archiver.cc
+++ b/source/src/Archiver.cc
@@ -41,12 +41,6 @@ namespace dqm4hep {
 
   namespace core {
 
-    Archiver::Archiver() : m_fileName(""), m_openingMode(""), m_pArchiveFile(nullptr), m_isOpened(false) {
-      /* nop */
-    }
-
-    //-------------------------------------------------------------------------------------------------
-
     Archiver::Archiver(const std::string &archiveFileName, const std::string &openingMode, bool allowSuffix) {
       THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->open(archiveFileName, openingMode, allowSuffix));
     }

--- a/source/src/PluginManager.cc
+++ b/source/src/PluginManager.cc
@@ -43,9 +43,7 @@ namespace dqm4hep {
     //-------------------------------------------------------------------------------------------------
 
     PluginManager::~PluginManager() {
-      for (auto iter : m_pluginMap) {
-        delete iter.second;
-      }
+      // No memory clean here, as the plugin instances are static
       m_pluginMap.clear();
       
       for (auto iter : m_dlLibraries) {

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -568,7 +568,30 @@ namespace dqm4hep {
             delete pParameterElement;
           }
 
-          pParentElement->RemoveChild(element);
+          TiXmlElement *previousElement(nullptr);
+          TiXmlNode *previousNode(element);
+          
+          while(nullptr != previousNode->PreviousSibling()) {
+            if(nullptr != previousNode->PreviousSibling()->ToElement()) {
+              previousElement = previousNode->PreviousSibling()->ToElement();
+              break;
+            }
+            else {
+              previousNode = previousNode->PreviousSibling();
+            }
+          }
+          // if a previous element is available, 
+          // continue the loop from it
+          if(nullptr != previousElement) {
+            pParentElement->RemoveChild(element);
+            element = previousElement;
+          }
+          // if no previous element is available,
+          // restart from the first child of input
+          else {
+            pParentElement->RemoveChild(element);
+            element = pParentElement->FirstChildElement();
+          }
         } else {
           // recursive call on childs !
           this->resolveAllDbSelect(element);

--- a/source/tests/test-me-json.cc
+++ b/source/tests/test-me-json.cc
@@ -67,7 +67,7 @@ int main(int argc, char *argv[]) {
   assert_test(nullptr == graphJson.value("reference", json(nullptr)));
   assert_test(0 != graphJson.count("path"));
   
-  dqm_debug(graphJson.dump(2));
+  DQM4HEP_NO_EXCEPTION( dqm_debug(graphJson.dump(2)); );
 
   return 0;
 }

--- a/source/tests/test-qtest-exact-ref-comp.cc
+++ b/source/tests/test-qtest-exact-ref-comp.cc
@@ -100,7 +100,7 @@ void fillDifferentNPoints(TGraph *graph) {
 
 int main(int argc, char *argv[]) {
   
-  Logger::createLogger("test-qtest-exact-ref-comp", {Logger::coloredConsole()});
+  DQM4HEP_NO_EXCEPTION( Logger::createLogger("test-qtest-exact-ref-comp", {Logger::coloredConsole()}); );
   Logger::setMainLogger("test-qtest-exact-ref-comp");
   Logger::setLogLevel(spdlog::level::debug);
 
@@ -140,7 +140,7 @@ int main(int argc, char *argv[]) {
   assert_test(STATUS_CODE_SUCCESS == meMgr->runQualityTest(testElement->path(), testElement->name(), qtestName, storage));
   assert_test(STATUS_CODE_SUCCESS == storage.report(testElement->path(), testElement->name(), qtestName, report));
   report.toJson(jsonReport);
-  std::cout << jsonReport.dump(2) << std::endl;
+  DQM4HEP_NO_EXCEPTION( std::cout << jsonReport.dump(2) << std::endl; );
   assert_test(report.m_qualityFlag == INVALID); // no reference assigned yet
   
   storage.clear();
@@ -148,7 +148,7 @@ int main(int argc, char *argv[]) {
   assert_test(STATUS_CODE_SUCCESS == meMgr->runQualityTest(testElement->path(), testElement->name(), qtestName, storage));
   assert_test(STATUS_CODE_SUCCESS == storage.report(testElement->path(), testElement->name(), qtestName, report));
   report.toJson(jsonReport);
-  std::cout << jsonReport.dump(2) << std::endl;
+  DQM4HEP_NO_EXCEPTION( std::cout << jsonReport.dump(2) << std::endl; );
   assert_test(report.m_qualityFlag == SUCCESS); // same histograms
   
   storage.clear();
@@ -156,7 +156,7 @@ int main(int argc, char *argv[]) {
   assert_test(STATUS_CODE_SUCCESS == meMgr->runQualityTest(testElement->path(), testElement->name(), qtestName, storage));
   assert_test(STATUS_CODE_SUCCESS == storage.report(testElement->path(), testElement->name(), qtestName, report));
   report.toJson(jsonReport);
-  std::cout << jsonReport.dump(2) << std::endl;
+  DQM4HEP_NO_EXCEPTION( std::cout << jsonReport.dump(2) << std::endl; );
   assert_test(report.m_qualityFlag == INVALID); // reference has a different binning
   
   storage.clear();
@@ -164,7 +164,7 @@ int main(int argc, char *argv[]) {
   assert_test(STATUS_CODE_SUCCESS == meMgr->runQualityTest(testElement->path(), testElement->name(), qtestName, storage));
   assert_test(STATUS_CODE_SUCCESS == storage.report(testElement->path(), testElement->name(), qtestName, report));
   report.toJson(jsonReport);
-  std::cout << jsonReport.dump(2) << std::endl;
+  DQM4HEP_NO_EXCEPTION( std::cout << jsonReport.dump(2) << std::endl; );
   assert_test(report.m_qualityFlag == INVALID); // wrong reference type
   
   storage.clear();
@@ -172,7 +172,7 @@ int main(int argc, char *argv[]) {
   assert_test(STATUS_CODE_SUCCESS == meMgr->runQualityTest(testElement->path(), testElement->name(), qtestName, storage));
   assert_test(STATUS_CODE_SUCCESS == storage.report(testElement->path(), testElement->name(), qtestName, report));
   report.toJson(jsonReport);
-  std::cout << jsonReport.dump(2) << std::endl;
+  DQM4HEP_NO_EXCEPTION( std::cout << jsonReport.dump(2) << std::endl; );
   assert_test(report.m_qualityFlag == ERROR); // valid test but reference is different
   
   assert_test(STATUS_CODE_SUCCESS == meMgr->removeMonitorElement(testElement->path(), testElement->name()));
@@ -192,7 +192,7 @@ int main(int argc, char *argv[]) {
   assert_test(STATUS_CODE_SUCCESS == meMgr->runQualityTest(testElement->path(), testElement->name(), qtestName, storage));
   assert_test(STATUS_CODE_SUCCESS == storage.report(testElement->path(), testElement->name(), qtestName, report));
   report.toJson(jsonReport);
-  std::cout << jsonReport.dump(2) << std::endl;
+  DQM4HEP_NO_EXCEPTION( std::cout << jsonReport.dump(2) << std::endl; );
   assert_test(report.m_qualityFlag == SUCCESS); // same scalar values
   
   storage.clear();
@@ -200,7 +200,7 @@ int main(int argc, char *argv[]) {
   assert_test(STATUS_CODE_SUCCESS == meMgr->runQualityTest(testElement->path(), testElement->name(), qtestName, storage));
   assert_test(STATUS_CODE_SUCCESS == storage.report(testElement->path(), testElement->name(), qtestName, report));
   report.toJson(jsonReport);
-  std::cout << jsonReport.dump(2) << std::endl;
+  DQM4HEP_NO_EXCEPTION( std::cout << jsonReport.dump(2) << std::endl; );
   assert_test(report.m_qualityFlag == ERROR); // different scalar values
   
   storage.clear();
@@ -208,7 +208,7 @@ int main(int argc, char *argv[]) {
   assert_test(STATUS_CODE_SUCCESS == meMgr->runQualityTest(testElement->path(), testElement->name(), qtestName, storage));
   assert_test(STATUS_CODE_SUCCESS == storage.report(testElement->path(), testElement->name(), qtestName, report));
   report.toJson(jsonReport);
-  std::cout << jsonReport.dump(2) << std::endl;
+  DQM4HEP_NO_EXCEPTION( std::cout << jsonReport.dump(2) << std::endl; );
   assert_test(report.m_qualityFlag == INVALID); // wrong reference type
 
   assert_test(STATUS_CODE_SUCCESS == meMgr->removeMonitorElement(testElement->path(), testElement->name()));
@@ -234,7 +234,7 @@ int main(int argc, char *argv[]) {
   assert_test(STATUS_CODE_SUCCESS == meMgr->runQualityTest(testElement->path(), testElement->name(), qtestName, storage));
   assert_test(STATUS_CODE_SUCCESS == storage.report(testElement->path(), testElement->name(), qtestName, report));
   report.toJson(jsonReport);
-  std::cout << jsonReport.dump(2) << std::endl;
+  DQM4HEP_NO_EXCEPTION( std::cout << jsonReport.dump(2) << std::endl; );
   assert_test(report.m_qualityFlag == SUCCESS); // same graphs
 
   storage.clear();
@@ -242,7 +242,7 @@ int main(int argc, char *argv[]) {
   assert_test(STATUS_CODE_SUCCESS == meMgr->runQualityTest(testElement->path(), testElement->name(), qtestName, storage));
   assert_test(STATUS_CODE_SUCCESS == storage.report(testElement->path(), testElement->name(), qtestName, report));
   report.toJson(jsonReport);
-  std::cout << jsonReport.dump(2) << std::endl;
+  DQM4HEP_NO_EXCEPTION( std::cout << jsonReport.dump(2) << std::endl; );
   assert_test(report.m_qualityFlag == INVALID); // reference has a different n points
   
   storage.clear();
@@ -250,7 +250,7 @@ int main(int argc, char *argv[]) {
   assert_test(STATUS_CODE_SUCCESS == meMgr->runQualityTest(testElement->path(), testElement->name(), qtestName, storage));
   assert_test(STATUS_CODE_SUCCESS == storage.report(testElement->path(), testElement->name(), qtestName, report));
   report.toJson(jsonReport);
-  std::cout << jsonReport.dump(2) << std::endl;
+  DQM4HEP_NO_EXCEPTION( std::cout << jsonReport.dump(2) << std::endl; );
   assert_test(report.m_qualityFlag == INVALID); // wrong reference type
   
   storage.clear();
@@ -258,7 +258,7 @@ int main(int argc, char *argv[]) {
   assert_test(STATUS_CODE_SUCCESS == meMgr->runQualityTest(testElement->path(), testElement->name(), qtestName, storage));
   assert_test(STATUS_CODE_SUCCESS == storage.report(testElement->path(), testElement->name(), qtestName, report));
   report.toJson(jsonReport);
-  std::cout << jsonReport.dump(2) << std::endl;
+  DQM4HEP_NO_EXCEPTION( std::cout << jsonReport.dump(2) << std::endl; );
   assert_test(report.m_qualityFlag == ERROR); // valid test but reference is different
   
   return 0;

--- a/source/tests/test-storage.cc
+++ b/source/tests/test-storage.cc
@@ -61,7 +61,7 @@ typedef Storage<Object> Storage_t;
 typedef Storage_t::ObjectList ObjectList;
 
 int main(int argc, char *argv[]) {
-  Logger::createLogger("test-storage", {Logger::coloredConsole()});
+  DQM4HEP_NO_EXCEPTION( Logger::createLogger("test-storage", {Logger::coloredConsole()}); );
   Logger::setMainLogger("test-storage");
   Logger::setLogLevel(spdlog::level::debug);
 


### PR DESCRIPTION

BEGINRELEASENOTES
- PluginManager
   - Clean memory of loaded libraries using `dlclose()`
- XMLParser
   - Fixed XML element insertion into XML tree in resolveAllDbSelect() and `resolveIncludes()`
- Added macro `DQM4HEP_NO_EXCEPTION` to shut down exceptions
- Main files and tests 
   - Fix coverity errors/warnings using `DQM4HEP_NO_EXCEPTION` macro

ENDRELEASENOTES