### PR TITLE
Make coverity scan working again

### DIFF
--- a/.travis-ci.d/coverity_scan.sh
+++ b/.travis-ci.d/coverity_scan.sh
@@ -10,17 +10,15 @@ export description=`date`
 export COVERITY_REPO=`echo ${TRAVIS_REPO_SLUG} | sed 's/\//\%2F/g'`
 
 # install coverity scan
-wget https://scan.coverity.com/download/linux64 --post-data "token=${COVERITY_SCAN_TOKEN}&project=${COVERITY_REPO}" -O coverity_tool.tgz
-mkdir cov-analysis-linux64 
-tar -xf coverity_tool.tgz -C cov-analysis-linux64 --strip-components=2
-export PATH=$PWD/cov-analysis-linux64/bin:$PATH
+wget https://scan.coverity.com/download/Linux --post-data "token=${COVERITY_SCAN_TOKEN}&project=${COVERITY_REPO}" -O coverity_tool.tgz
+mkdir cov-analysis-Linux
+tar -xf coverity_tool.tgz -C cov-analysis-Linux --strip-components=2 &> /dev/null
+export PATH=$PWD/cov-analysis-Linux/bin:$PATH
 
 # run cmake and build with coverity
 source dependencies/root/bin/thisroot.sh
 mkdir -p build && cd build
 cmake -DINSTALL_DOC=OFF -Dxdrstream_DIR=$PWD/../dependencies/xdrstream -DCMAKE_MODULE_PATH=$PWD/../dependencies/dqm4hep/cmake -DBUILD_TESTS=ON ..
-cov-configure --comptype gcc --compiler /usr/bin/${CC}
-cov-configure --comptype g++ --compiler /usr/bin/${CXX}
 cov-build --dir cov-int make -j2
 tar czvf myproject.tgz cov-int
 

--- a/.travis-ci.d/deploy-doxygen.sh
+++ b/.travis-ci.d/deploy-doxygen.sh
@@ -5,7 +5,7 @@ pkgVersion=""
 repository=$(basename $TRAVIS_REPO_SLUG | tr '[:upper:]' '[:lower:]')
 username=$(dirname $TRAVIS_REPO_SLUG | tr '[:upper:]' '[:lower:]')
 
-if [ ! "${CXX}" = "g++-4.9" ] || [ ! "${TRAVIS_OS_NAME}" = "linux" ]
+if [ ! "${CXX}" = "g++" ] || [ ! "${TRAVIS_OS_NAME}" = "linux" ]
 then
   echo "Build and push doxygen only one per push"
   exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ sudo: required
 os:
   - linux
 
-env:
-  global:
-    - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
-
 addons:
   apt:
     sources:
@@ -18,13 +14,13 @@ addons:
       - g++-4.9
 
 script:
-  - if [[ "${TRAVIS_EVENT_TYPE}" == "cron" && "${CXX}" == "g++-4.9"  ]];
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 90
+  - if [[ "${TRAVIS_EVENT_TYPE}" == "cron" && "${CXX}" == "g++"  ]];
     then ./.travis-ci.d/coverity_scan.sh;
     else ./.travis-ci.d/compile_and_test.sh;
     fi
 
 before_install:
-  - eval "${MATRIX_EVAL}"
   - ./.travis-ci.d/install_dependencies.sh
 
 after_success:


### PR DESCRIPTION
BEGINRELEASENOTES
- TravisCI scripts
   - Use update-alternative to point on the correct version of gcc. 
   - Adjusted CI scripts to point on g++ and not g++-4.9

ENDRELEASENOTES