### PR TITLE
Xml for loop

### DIFF
--- a/source/include/dqm4hep/XMLParser.h
+++ b/source/include/dqm4hep/XMLParser.h
@@ -153,6 +153,7 @@ namespace dqm4hep {
     private:
       // parsing functions
       void resolveIncludes();
+      void resolveForLoops();
       void resolveConstants();
       void resolveDbParameters();
 
@@ -174,6 +175,10 @@ namespace dqm4hep {
       // database related functions
       void readDatabases();
       void resolveAllDbSelect(TiXmlElement *pXmlElement);
+      
+      // for loop related
+      void resolveForLoops(TiXmlElement *element);
+      void resolveForLoop(TiXmlNode *node, const std::string &id, float value);
 
     private:
       typedef std::map<std::string, std::shared_ptr<DBInterface>> DBInterfaceMap;

--- a/source/tests/test-xmlparser.cc
+++ b/source/tests/test-xmlparser.cc
@@ -59,6 +59,11 @@ int main(int /*argc*/, char *argv[]) {
   }
 
   assert_test(parseOkay);
+  
+  auto document = parser.document();
+  TiXmlPrinter printer;
+  document.Accept(&printer);
+  std::cout << printer.Str() << std::endl;
 
   TiXmlElement *root = parser.document().RootElement();
   assert_test(root != nullptr);

--- a/tests/test_xmlparser.xml
+++ b/tests/test_xmlparser.xml
@@ -1,5 +1,12 @@
 <dqm4hep>
   
+  <counters>
+    <for id="count" begin="0" end="10" increment="1">
+      <!-- This counter value is set to $FOR{count} -->
+      <counter name="${user}" value="$FOR{count}" />
+    </for>
+  </counters>
+  
   <constants>
     <constant name="user" value="superman"/>
     <constant name="planet" value="krypton"/>


### PR DESCRIPTION
BEGINRELEASENOTES
- New XML parsing with for loops
    - Allow for using element `<for>` xml element to duplicate content
   - Nested loops are allowed
    - Example:
```xml
<for id="count" begin="0" end="5" increment="1">
  <!-- This counter value is set to $FOR{count} -->
  <counter value="$FOR{count}" />
<for>
```
will be transformed to : 
```xml
<!-- This counter value is set to 0 -->
<counter value="0" />
<!-- This counter value is set to 1 -->
<counter value="1" />
<!-- This counter value is set to 2 -->
<counter value="2" />
<!-- This counter value is set to 3 -->
<counter value="3" />
<!-- This counter value is set to 4 -->
<counter value="4" />
<!-- This counter value is set to 5 -->
<counter value="5" />
```

ENDRELEASENOTES