### PR TITLE
Fix xml parser

### DIFF
--- a/source/include/dqm4hep/XMLParser.h
+++ b/source/include/dqm4hep/XMLParser.h
@@ -178,7 +178,7 @@ namespace dqm4hep {
       
       // for loop related
       void resolveForLoops(TiXmlElement *element);
-      void resolveForLoop(TiXmlNode *node, const std::string &id, float value);
+      void resolveForLoop(TiXmlNode *node, const std::string &id, int value);
 
     private:
       typedef std::map<std::string, std::shared_ptr<DBInterface>> DBInterfaceMap;

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -683,7 +683,7 @@ namespace dqm4hep {
           attr->SetValue(attrValue);
         }
         // make it recursive
-        for(auto child = nodeElement->FirstChild() ; nullptr != child ; child->NextSibling()) {
+        for(auto child = nodeElement->FirstChild() ; nullptr != child ; child = child->NextSibling()) {
           resolveForLoop(child, id, value);
         }
       }

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -626,31 +626,29 @@ namespace dqm4hep {
         if(nullptr == parent) {
           return;
         }
-        float begin(0.f), end(0.f), increment(0.f);
+        int begin(0), end(0), increment(0);
         std::string loopId;
-        if(TIXML_SUCCESS != element->QueryFloatAttribute("begin", &begin)) {
+        if(TIXML_SUCCESS != element->QueryIntAttribute("begin", &begin)) {
           dqm_error( "XMLParser::resolveForLoops: <for> element with invalid 'begin' attribute !" );
           throw StatusCodeException(STATUS_CODE_FAILURE);
         }
-        if(TIXML_SUCCESS != element->QueryFloatAttribute("end", &end)) {
+        if(TIXML_SUCCESS != element->QueryIntAttribute("end", &end)) {
           dqm_error( "XMLParser::resolveForLoops: <for> element with invalid 'end' attribute !" );
-          throw StatusCodeException(STATUS_CODE_FAILURE);
-        }
-        if(TIXML_SUCCESS != element->QueryFloatAttribute("increment", &increment)) {
-          dqm_error( "XMLParser::resolveForLoops: <for> element with invalid 'increment' attribute !" );
           throw StatusCodeException(STATUS_CODE_FAILURE);
         }
         if(TIXML_SUCCESS != element->QueryStringAttribute("id", &loopId) or loopId.empty()) {
           dqm_error( "XMLParser::resolveForLoops: <for> element with invalid 'id' attribute !" );
           throw StatusCodeException(STATUS_CODE_FAILURE);
         }
+        // optional attribute
+        element->QueryIntAttribute("increment", &increment);
         const bool forwardLoop(begin < end);
         if((forwardLoop and increment < 0) or (not forwardLoop and increment > 0)) {
           dqm_error( "XMLParser::resolveForLoops: <for> element with infinite loop detected !" );
           throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
         }
         std::cout << "Found a valid for loop: id = " << loopId << std::endl; 
-        for(float i=begin ; i<=end ; i+=increment) {
+        for(int i=begin ; i<=end ; i+=increment) {
           for(auto child = element->FirstChild() ; nullptr != child ; child = child->NextSibling()) {
             auto cloneChild = child->Clone();
             if(nullptr != cloneChild) {
@@ -669,7 +667,7 @@ namespace dqm4hep {
     
     //----------------------------------------------------------------------------------------------------
     
-    void XMLParser::resolveForLoop(TiXmlNode *node, const std::string &id, float value) {
+    void XMLParser::resolveForLoop(TiXmlNode *node, const std::string &id, int value) {
       std::string loopIDStr = "$FOR{" + id + "}";
       std::string valueStr = typeToString(value);
       if(node->Type() == TiXmlNode::TINYXML_ELEMENT) {

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -269,8 +269,6 @@ namespace dqm4hep {
           // continue the while from it
           if(nullptr != previousElement) {
             dqm_debug( "XMLParser::resolveIncludes(): Previous element found" );
-            std::cout << "Child: " << child->ValueStr() << std::endl;
-            std::cout << "Previous: " << previousElement->ValueStr() << std::endl;
             node->RemoveChild(child);
             child = previousElement;
           }
@@ -647,14 +645,11 @@ namespace dqm4hep {
           dqm_error( "XMLParser::resolveForLoops: <for> element with infinite loop detected !" );
           throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
         }
-        std::cout << "Found a valid for loop: id = " << loopId << std::endl; 
         for(int i=begin ; i<=end ; i+=increment) {
           for(auto child = element->FirstChild() ; nullptr != child ; child = child->NextSibling()) {
             auto cloneChild = child->Clone();
             if(nullptr != cloneChild) {
-              std::cout << "Resolve ..." << std::endl;
               resolveForLoop(cloneChild, loopId, i);
-              std::cout << "Resolve ... OK" << std::endl;
               parent->InsertBeforeChild(element, *cloneChild);
               delete cloneChild;
             }            


### PR DESCRIPTION
BEGINRELEASENOTES
- For loop feature:
   - Fixed loop increment in for loop resolve
   - Changed begin, end and increment variables to integers
   - Make increment optional (default is 1)
- Removed all nasty printout with cout


ENDRELEASENOTES