### PR TITLE
Refactor of statistics monitoring (global & process mem/cpu/network)

### DIFF
--- a/source/include/dqm4hep/Internal.h
+++ b/source/include/dqm4hep/Internal.h
@@ -436,7 +436,7 @@ namespace dqm4hep {
       dqm_float cpuTot = {0.};      // total (sys+user) cpu load used by this process in percentage
       dqm_long vm = {0L};           // virtual memory used by this process in KB
       dqm_long rss = {0L};          // resident memory used by this process in KB
-      timeval lastPollTime;         // last time process stats were polled
+      timeval lastPollTime {0, 0}; // last time process stats were polled
     };
 
     //-------------------------------------------------------------------------------------------------

--- a/source/include/dqm4hep/Internal.h
+++ b/source/include/dqm4hep/Internal.h
@@ -436,6 +436,7 @@ namespace dqm4hep {
       dqm_float cpuTot = {0.};      // total (sys+user) cpu load used by this process in percentage
       dqm_long vm = {0L};           // virtual memory used by this process in KB
       dqm_long rss = {0L};          // resident memory used by this process in KB
+      timeval lastPollTime;         // last time process stats were polled
     };
 
     //-------------------------------------------------------------------------------------------------

--- a/source/include/dqm4hep/Internal.h
+++ b/source/include/dqm4hep/Internal.h
@@ -54,7 +54,7 @@
 #include <thread>
 #include <unistd.h>
 
-// apple stuff for stdint.h
+// -- apple headers for stdint.h
 #ifdef __APPLE__
 #include <_types.h>
 #include <_types/_uint16_t.h>
@@ -65,13 +65,10 @@
 #include <sys/_pthread/_pthread_types.h>
 #include <sys/_types/_int16_t.h>
 #include <sys/_types/_int64_t.h>
-// for memStats
-#include <sys/sysctl.h>
-#include <mach/mach.h>
 #else
-#include <sys/sysinfo.h>
 #include <bits/pthreadtypes.h>
 #include <stdint.h>
+#include <sys/sysinfo.h>
 #endif
 
 // -- dqm4hep headers
@@ -143,6 +140,8 @@ namespace dqm4hep {
     typedef float dqm_real;
     typedef float dqm_float;
     typedef double dqm_double;
+    typedef long dqm_long;
+    typedef long long dqm_long_long;
     typedef bool dqm_bool;
     typedef int64_t dqm_int;
     typedef uint64_t dqm_uint;
@@ -379,52 +378,105 @@ namespace dqm4hep {
     //-------------------------------------------------------------------------------------------------
     
     /**
+     *  @brief  CpuStats struct
+     */
+    struct CpuStats {
+      dqm_float load1m = {0.};  // cpu load average over 1 m
+      dqm_float load5m = {0.};  // cpu load average over 5 m
+      dqm_float load15m = {0.}; // cpu load average over 15 m
+      dqm_float user = {0.};    // cpu user load in percentage
+      dqm_float sys = {0.};     // cpu sys load in percentage
+      dqm_float tot = {0.};     // cpu user+sys load in percentage
+      dqm_float idle = {0.};    // cpu idle percentage
+    };
+
+    //-------------------------------------------------------------------------------------------------
+
+    /**
+     *  @brief  Get some memory stats
+     *
+     *  @param  object the CpuStats object to receive
+     */
+    void cpuStats(CpuStats &stats, dqm_int sampleTime = 1 /*s*/);
+    //-------------------------------------------------------------------------------------------------
+
+    /**
      *  @brief  MemoryStats struct
      *          All units in Mb
      */
     struct MemoryStats {
-      double   vmtot  = {0.};
-      double   vmused = {0.};
-      double   vmproc = {0.};
-      double   rsstot  = {0.};
-      double   rssused = {0.};
-      double   rssproc = {0.};
+      dqm_int vmTot = {0};   // total virtual RAM (physical RAM + swap) in MB
+      dqm_int vmUsed = {0};  // used virtual RAM (physical RAM + swap) in MB
+      dqm_int vmFree = {0};  // free virtual RAM (physical RAM + swap) in MB
+      dqm_int rssTot = {0};  // total physical RAM in MB
+      dqm_int rssUsed = {0}; // used  physical RAM in MB
     };
-    
+
     //-------------------------------------------------------------------------------------------------
-    
+
     /**
      *  @brief  Get some memory stats
      *
      *  @param  object the MemoryStats object to receive
      */
     void memStats(MemoryStats &stats);
-    
+
     //-------------------------------------------------------------------------------------------------
-    
+
+    /**
+     *  @brief  ProcessStats struct
+     *          All memory units in Mb
+     */
+    struct ProcessStats {
+      dqm_float cpuTimeUser = {0.}; // user time used by this process in seconds
+      dqm_float cpuTimeSys = {0.};  // system time used by this process in seconds
+      dqm_float cpuTimeTot = {0.};  // total time used by this process in seconds
+      dqm_float cpuUser = {0.};     // cpu user load used by this process in percentage
+      dqm_float cpuSys = {0.};      // cpu sys load used by this process in percentage
+      dqm_float cpuTot = {0.};      // total (sys+user) cpu load used by this process in percentage
+      dqm_long vm = {0L};           // virtual memory used by this process in KB
+      dqm_long rss = {0L};          // resident memory used by this process in KB
+    };
+
+    //-------------------------------------------------------------------------------------------------
+
+    /**
+     *  @brief  Get stats from current process
+     *
+     *  @param  object the ProcessStats object to receive
+     */
+    void procStats(ProcessStats &stats);
+    //-------------------------------------------------------------------------------------------------
+
     /**
      *  @brief  INetworkStats struct
      */
     struct INetworkStats {
-      dqm_stat    rcv_bytes;
-      dqm_stat    rcv_packets;
-      dqm_stat    rcv_errs;
-      dqm_stat    snd_bytes;
-      dqm_stat    snd_packets;
-      dqm_stat    snd_errs;
+      dqm_stat tot_rcv_kbytes = {0L};
+      dqm_stat tot_rcv_packets = {0L};
+      dqm_stat tot_rcv_errs = {0L};
+      dqm_stat tot_snd_kbytes = {0L};
+      dqm_stat tot_snd_packets = {0L};
+      dqm_stat tot_snd_errs = {0L};
+      dqm_stat rcv_rate_kbytes = {0L};
+      dqm_stat rcv_rate_packets = {0L};
+      dqm_stat rcv_rate_errs = {0L};
+      dqm_stat snd_rate_kbytes = {0L};
+      dqm_stat snd_rate_packets = {0L};
+      dqm_stat snd_rate_errs = {0L};
     };
-    
+
     typedef std::map<std::string, INetworkStats> NetworkStats;
-    
+
     //-------------------------------------------------------------------------------------------------
-    
+
     /**
      *  @brief  Get some network stats
      *
      *  @param  object the NetworkStats object to receive
      */
-    void netStats(NetworkStats &stats);
-  }
-}
+    void netStats(NetworkStats &stats, dqm_int sampleTime = 1 /*s*/);
+  } // namespace core
+} // namespace dqm4hep
 
 #endif //  DQM4HEP_ENUMERATORS_H

--- a/source/main/dqm4hep-cpustats.cc
+++ b/source/main/dqm4hep-cpustats.cc
@@ -32,17 +32,20 @@
 // -- dqm4hep headers
 #include <dqm4hep/Internal.h>
 #include <iomanip>
+#include <sys/time.h>
 
 #define wfmt_value(width, val) std::setw(width) << std::left << std::setprecision(1) << std::fixed << val
 #define fmt_value(val) wfmt_value(10, val)
 
 int main(int /*argc*/, char ** /*argv[]*/) {
 
+  struct timeval timeStart;
+  gettimeofday(&timeStart, NULL);
+  dqm4hep::core::ProcessStats procInfo;
+  procInfo.lastPollTime = timeStart;
   while (1) {
     dqm4hep::core::CpuStats cpuInfo;
     dqm4hep::core::cpuStats(cpuInfo);
-
-    dqm4hep::core::ProcessStats procInfo;
     dqm4hep::core::procStats(procInfo);
 
     // System Info
@@ -55,11 +58,10 @@ int main(int /*argc*/, char ** /*argv[]*/) {
               << fmt_value(cpuInfo.tot) << fmt_value(cpuInfo.idle) << std::endl;
 
     // Process Info
-    std::cout << std::setw(16) << std::left << "Process Load" << fmt_value("User (%)") << fmt_value("Sys (%)")
+    std::cout << std::setw(16) << std::left << "Process Load" << fmt_value("User (%)") << fmt_value("Sys (%)") << fmt_value("Tot (%)")
               << wfmt_value(20, "User cpuTime (s)") << wfmt_value(20, "Sys cpuTime (s)") << std::endl;
 
-    std::cout << std::setw(16) << std::left << " " << fmt_value(procInfo.cpuUser) << fmt_value(procInfo.cpuSys)
-              << wfmt_value(20, procInfo.cpuTimeUser) << wfmt_value(20, procInfo.cpuTimeSys) << std::endl;
+    std::cout << std::setw(16) << std::left << " " << fmt_value(procInfo.cpuUser) << fmt_value(procInfo.cpuSys) << fmt_value(procInfo.cpuTot) << wfmt_value(20, procInfo.cpuTimeUser) << wfmt_value(20, procInfo.cpuTimeSys) << std::endl;
     std::cout << std::endl;
   }
 

--- a/source/main/dqm4hep-cpustats.cc
+++ b/source/main/dqm4hep-cpustats.cc
@@ -1,0 +1,67 @@
+/// \file dqm4hep-dump-plugins.cc
+/*
+ *
+ * dqm4hep-dump-plugins.cc main source file template automatically generated
+ * Creation date : mer. nov. 5 2014
+ *
+ * This file is part of DQM4HEP libraries.
+ *
+ * DQM4HEP is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * based upon these libraries are permitted. Any copy of these libraries
+ * must include this copyright notice.
+ *
+ * DQM4HEP is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DQM4HEP.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Remi Ete
+ * @copyright CNRS , IPNL
+ *
+ * Create a quality test template file a ROOT file.
+ * Parses the different directories and populate the
+ * qtest file with found objects.
+ */
+
+// -- dqm4hep headers
+#include <dqm4hep/Internal.h>
+#include <iomanip>
+
+#define wfmt_value(width, val) std::setw(width) << std::left << std::setprecision(1) << std::fixed << val
+#define fmt_value(val) wfmt_value(10, val)
+
+int main(int /*argc*/, char ** /*argv[]*/) {
+
+  while (1) {
+    dqm4hep::core::CpuStats cpuInfo;
+    dqm4hep::core::cpuStats(cpuInfo);
+
+    dqm4hep::core::ProcessStats procInfo;
+    dqm4hep::core::procStats(procInfo);
+
+    // System Info
+    std::cout << std::setw(16) << std::left << "System Load" << fmt_value("1m (%)") << fmt_value("5m (%)")
+              << fmt_value("15m (%)") << fmt_value("User (%)") << fmt_value("Sys (%)") << fmt_value("Total (%)")
+              << fmt_value("Idle (%)") << std::endl;
+
+    std::cout << std::setw(16) << std::left << " " << fmt_value(cpuInfo.load1m) << fmt_value(cpuInfo.load5m)
+              << fmt_value(cpuInfo.load15m) << fmt_value(cpuInfo.user) << fmt_value(cpuInfo.sys)
+              << fmt_value(cpuInfo.tot) << fmt_value(cpuInfo.idle) << std::endl;
+
+    // Process Info
+    std::cout << std::setw(16) << std::left << "Process Load" << fmt_value("User (%)") << fmt_value("Sys (%)")
+              << wfmt_value(20, "User cpuTime (s)") << wfmt_value(20, "Sys cpuTime (s)") << std::endl;
+
+    std::cout << std::setw(16) << std::left << " " << fmt_value(procInfo.cpuUser) << fmt_value(procInfo.cpuSys)
+              << wfmt_value(20, procInfo.cpuTimeUser) << wfmt_value(20, procInfo.cpuTimeSys) << std::endl;
+    std::cout << std::endl;
+  }
+
+  return 0;
+}

--- a/source/main/dqm4hep-memstats.cc
+++ b/source/main/dqm4hep-memstats.cc
@@ -36,36 +36,26 @@
 #define fmt_value(val) std::setw(16) << std::left << std::setprecision(1) << std::fixed << val
 
 int main(int /*argc*/, char ** /*argv[]*/) {
-  
-  while(1) {
-    
-    dqm4hep::core::MemoryStats stats;
-    dqm4hep::core::memStats(stats);
-    
-    std::cout << std::setw(10) << std::left << "Memory" 
-              << fmt_value("Total (Mb)") 
-              << fmt_value("Used (Mb)")
-              << fmt_value("Process (Mb)") 
-              << fmt_value("Used (%)")
-              << fmt_value("Proc used (%)")
-              << std::endl;
-    
-    std::cout << std::setw(10) << std::left << "Resident" 
-              << fmt_value(stats.rsstot) 
-              << fmt_value(stats.rssused)
-              << fmt_value(stats.rssproc)
-              << fmt_value((stats.rssused/(stats.rsstot*1.))*100)
-              << fmt_value((stats.rssproc/(stats.rsstot*1.))*100)
-              << std::endl;
-    
-    std::cout << std::setw(10) << std::left << "Virtual" 
-              << fmt_value(stats.vmtot)
-              << fmt_value(stats.vmused) 
-              << fmt_value(stats.vmproc) 
-              << fmt_value((stats.vmused/(stats.vmtot*1.))*100)
-              << fmt_value((stats.vmproc/(stats.vmtot*1.))*100.)
-              << std::endl;
-    
+
+  while (1) {
+
+    dqm4hep::core::MemoryStats memInfo;
+    dqm4hep::core::memStats(memInfo);
+
+    dqm4hep::core::ProcessStats procInfo;
+    dqm4hep::core::procStats(procInfo);
+
+    std::cout << std::setw(10) << std::left << "Memory" << fmt_value("Total (Mb)") << fmt_value("Used (Mb)")
+              << fmt_value("Process (Mb)") << fmt_value("Used (%)") << fmt_value("Proc used (%)") << std::endl;
+
+    std::cout << std::setw(10) << std::left << "Resident" << fmt_value(memInfo.rssTot) << fmt_value(memInfo.rssUsed)
+              << fmt_value(procInfo.rss / 1024.) << fmt_value((memInfo.rssUsed / (memInfo.rssTot * 1.)) * 100)
+              << fmt_value(((procInfo.rss / 1024.) / (memInfo.rssTot * 1.)) * 100) << std::endl;
+
+    std::cout << std::setw(10) << std::left << "Virtual" << fmt_value(memInfo.vmTot) << fmt_value(memInfo.vmUsed)
+              << fmt_value(procInfo.vm / 1024.) << fmt_value((memInfo.vmUsed / (memInfo.vmTot * 1.)) * 100)
+              << fmt_value(((procInfo.vm / 1024.) / (memInfo.vmTot * 1.)) * 100.) << std::endl;
+
     std::cout << std::endl;
     dqm4hep::core::sleep(std::chrono::seconds(2));
   }

--- a/source/main/dqm4hep-netstats.cc
+++ b/source/main/dqm4hep-netstats.cc
@@ -1,0 +1,67 @@
+/// \file dqm4hep-dump-plugins.cc
+/*
+ *
+ * dqm4hep-dump-plugins.cc main source file template automatically generated
+ * Creation date : mer. nov. 5 2014
+ *
+ * This file is part of DQM4HEP libraries.
+ *
+ * DQM4HEP is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * based upon these libraries are permitted. Any copy of these libraries
+ * must include this copyright notice.
+ *
+ * DQM4HEP is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DQM4HEP.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Remi Ete
+ * @copyright CNRS , IPNL
+ *
+ * Create a quality test template file a ROOT file.
+ * Parses the different directories and populate the
+ * qtest file with found objects.
+ */
+
+// -- dqm4hep headers
+#include <dqm4hep/Internal.h>
+#include <iomanip>
+
+#define wfmt_value(width, val) std::setw(width) << std::left << std::setprecision(1) << std::fixed << val
+#define fmt_value(val) wfmt_value(20, val)
+
+int main(int /*argc*/, char ** /*argv[]*/) {
+
+  while (1) {
+
+    dqm4hep::core::NetworkStats nStats;
+    dqm4hep::core::netStats(nStats, 1);
+
+    std::cout << std::setw(68) << "" << std::setw(68) << "Total" << std::setw(50) << "|\t" << std::setw(60) << "Rate"
+              << std::endl;
+    std::cout << std::setw(16) << std::left << "Interface" << fmt_value("Sent (kb)") << fmt_value("Received (kb)")
+              << fmt_value("Sent packets") << fmt_value("Rcvd packets") << fmt_value("Rcvd errors")
+              << fmt_value("Sent errors") << "|\t" << fmt_value("Sent (kb/s)") << fmt_value("Rcvd (kb/s)")
+              << fmt_value("Sent (packets/s)") << fmt_value("Rcvd (packets/s)") << fmt_value("Sent (error/s)")
+              << fmt_value("Rcvd (error/s)") << std::endl;
+
+    for (const auto &stat : nStats) {
+      std::cout << std::setw(16) << std::left << stat.first << fmt_value(stat.second.tot_snd_kbytes)
+                << fmt_value(stat.second.tot_rcv_kbytes) << fmt_value(stat.second.tot_snd_packets)
+                << fmt_value(stat.second.tot_rcv_packets) << fmt_value(stat.second.tot_rcv_errs)
+                << fmt_value(stat.second.tot_snd_errs) << "|\t" << fmt_value(stat.second.rcv_rate_kbytes)
+                << fmt_value(stat.second.rcv_rate_packets) << fmt_value(stat.second.rcv_rate_errs)
+                << fmt_value(stat.second.snd_rate_kbytes) << fmt_value(stat.second.snd_rate_packets)
+                << fmt_value(stat.second.snd_rate_errs) << std::endl;
+    }
+    dqm4hep::core::sleep(std::chrono::seconds(2));
+  }
+
+  return 0;
+}

--- a/source/src/Internal.cc
+++ b/source/src/Internal.cc
@@ -142,8 +142,8 @@ namespace dqm4hep {
         dqm_error("[{0}] - Failed to open '/proc/meminfo'", __FUNCTION__);
         throw core::StatusCodeException(STATUS_CODE_FAILURE);
       }
-      dqm_long_long free = {0LL};
-      dqm_long_long total = {0LL};
+      dqm_long_long memFree = {0LL};
+      dqm_long_long memTotal = {0LL};
 
       dqm_long_long swap_total = {0LL};
       dqm_long_long swap_free = {0LL};
@@ -151,11 +151,11 @@ namespace dqm4hep {
       while (s.Gets(f)) {
         if (s.BeginsWith("MemTotal")) {
           TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
-          total = (s.Atoi() / 1024);
+          memTotal = (s.Atoi() / 1024);
         }
         if (s.BeginsWith("MemFree")) {
           TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
-          free = (s.Atoi() / 1024);
+          memFree = (s.Atoi() / 1024);
         }
         if (s.BeginsWith("SwapTotal")) {
           TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
@@ -168,11 +168,11 @@ namespace dqm4hep {
       }
       fclose(f);
 
-      stats.vmTot = (dqm_int)(total + swap_total);
-      stats.vmUsed = (dqm_int)(total - free);
-      stats.vmFree = (dqm_int)(free + swap_free);
-      stats.rssTot = (dqm_int)(total);
-      stats.rssUsed = (dqm_int)((total - free));
+      stats.vmTot = (dqm_int)(memTotal + swap_total);
+      stats.vmUsed = (dqm_int)(memTotal - rssFree);
+      stats.vmFree = (dqm_int)(memFree + swap_free);
+      stats.rssTot = (dqm_int)(memTotal);
+      stats.rssUsed = (dqm_int)(memTotal - memFree);
     }
 
     //-------------------------------------------------------------------------------------------------

--- a/source/src/Internal.cc
+++ b/source/src/Internal.cc
@@ -30,6 +30,9 @@
 
 // -- ROOT header
 #include <TSystem.h>
+// #if defined(__linux__)
+#include <TPRegexp.h>
+// #endif
 
 #include <cstring>
 #include <dirent.h>
@@ -41,8 +44,6 @@ namespace dqm4hep {
 
 #if defined(__linux__)
 
-// -- ROOT header
-#include <TPRegexp.h>
 
 #if defined(DQM4HEP_WITH_PROC_FS)
     // only for unix systems

--- a/source/src/Internal.cc
+++ b/source/src/Internal.cc
@@ -45,6 +45,10 @@ namespace dqm4hep {
 
 #if defined(__linux__) || defined(__APPLE__)
 
+    /**
+     *  @brief  Compute process cpu load for osx and linux
+     *  @param  stats the ProcessStats struct to fill
+     */
     static void procCpuStats(ProcessStats &stats) {
       struct rusage ru;
       if (getrusage(RUSAGE_SELF, &ru) < 0) {
@@ -83,8 +87,9 @@ namespace dqm4hep {
     }
 
     //-------------------------------------------------------------------------------------------------
+
     /**
-     *  @brief  Compute network rate and fill NetworkStats struct
+     *  @brief  Compute network rate and fill NetworkStats struct for osx and linux
      *  @param  stats the NetworkStats struct to fill
      *  @param  tempStats the NetworkStats struct to compare with
      *  @param  sampleTime time between the two NetworkStats reading
@@ -142,6 +147,10 @@ namespace dqm4hep {
 
     //-------------------------------------------------------------------------------------------------
 
+    /**
+     *  @brief  Read cpu load for linux
+     *  @param  ticks an array of length 4 to store the cpu ticks value
+     */
     static void readLinuxCpu(long *ticks) {
       ticks[0] = ticks[1] = ticks[2] = ticks[3] = 0;
 
@@ -161,6 +170,11 @@ namespace dqm4hep {
 
     //-------------------------------------------------------------------------------------------------
 
+    /**
+     *  @brief  Get cpu stats for linux
+     *  @param  stats the CpuStats struct to store the data
+     *  @param  sampleTime the time between two cpu reading to compute the load
+     */
     static void linuxCpuStats(CpuStats &stats, dqm_int sampleTime) {
       dqm_double avg[3] = {-1.};
 #ifndef R__WINGCC
@@ -202,6 +216,10 @@ namespace dqm4hep {
 
     //-------------------------------------------------------------------------------------------------
 
+    /**
+     *  @brief  Get memory stats for linux
+     *  @param  stats the MemoryStats struct to store the data
+     */
     static void linuxMemStats(MemoryStats &stats) {
       TString s;
       FILE *f = fopen("/proc/meminfo", "r");
@@ -244,6 +262,10 @@ namespace dqm4hep {
 
     //-------------------------------------------------------------------------------------------------
 
+    /**
+     *  @brief  Get process stats for linux
+     *  @param  stats the ProcessStats struct to store the data
+     */
     static void linuxProcStats(ProcessStats &stats) {
 
       procCpuStats(stats);
@@ -265,6 +287,10 @@ namespace dqm4hep {
 
     //-------------------------------------------------------------------------------------------------
 
+    /**
+     *  @brief  Read network stats for linux from /proc/net.dev
+     *  @param  stats the NetworkStats struct to store the data
+     */
     static void  readLinuxNet(NetworkStats &stats) {
 #if defined(DQM4HEP_WITH_PROC_FS)
       FILE *file = fopen("/proc/net/dev", "r");
@@ -320,6 +346,11 @@ namespace dqm4hep {
 
     //-------------------------------------------------------------------------------------------------
 
+    /**
+     *  @brief  Get network stats for linux
+     *  @param  stats the NetworkStats struct to store the data
+     *  @param  sampleTime the time between two network i/o reading to compute the rate
+     */
     static void linuxNetStats(NetworkStats &stats, dqm_int sampleTime) {
       NetworkStats tempStats;
       readLinuxNet(tempStats);
@@ -339,9 +370,13 @@ namespace dqm4hep {
 #include <net/route.h>
 #include <sys/sysctl.h>
 
-        //-------------------------------------------------------------------------------------------------
+    //-------------------------------------------------------------------------------------------------
 
-        static void readDarwinCpu(long *ticks) {
+    /**
+     *  @brief  Read cpu load for osx
+     *  @param  ticks an array of length 4 to store the cpu ticks value
+     */
+    static void readDarwinCpu(long *ticks) {
       ticks[0] = ticks[1] = ticks[2] = ticks[3] = 0;
 
       host_cpu_load_info_data_t cpu;
@@ -361,6 +396,11 @@ namespace dqm4hep {
 
     //-------------------------------------------------------------------------------------------------
 
+    /**
+     *  @brief  Get cpu stats for osx
+     *  @param  stats the CpuStats struct to store the data
+     *  @param  sampleTime the time between two cpu reading to compute the load
+     */
     static void darwinCpuStats(CpuStats &stats, dqm_int sampleTime) {
       dqm_double avg[3] = {-1.};
       if (getloadavg(avg, sizeof(avg)) < 0) {
@@ -398,6 +438,10 @@ namespace dqm4hep {
 
     //-------------------------------------------------------------------------------------------------
 
+    /**
+     *  @brief  Get memory stats for osx
+     *  @param  stats the MemoryStats struct to store the data
+     */
     static void darwinMemStats(MemoryStats &stats) {
       vm_statistics_data_t vm_info;
       mach_msg_type_number_t count = HOST_VM_INFO_COUNT;
@@ -457,6 +501,10 @@ namespace dqm4hep {
 
     //-------------------------------------------------------------------------------------------------
 
+    /**
+     *  @brief  Get process stats for osx
+     *  @param  stats the ProcessStats struct to store the data
+     */
     static void darwinProcStats(ProcessStats &stats) {
 #ifdef _LP64
 #define vm_region vm_region_64
@@ -551,6 +599,10 @@ namespace dqm4hep {
 
     //-------------------------------------------------------------------------------------------------
 
+    /**
+     *  @brief  Read network stats for osx via sysctl
+     *  @param  stats the NetworkStats struct to store the data
+     */
     static void readDarwinNet(NetworkStats &stats) {
       double unit = 1024.; // Store everything in kb
 
@@ -623,6 +675,11 @@ namespace dqm4hep {
 
     //-------------------------------------------------------------------------------------------------
 
+    /**
+     *  @brief  Get network stats for osx
+     *  @param  stats the NetworkStats struct to store the data
+     *  @param  sampleTime the time between two network i/o reading to compute the rate
+     */
     static void darwinNetStats(NetworkStats &stats, dqm_int sampleTime) {
 
       NetworkStats tempStats;

--- a/source/src/Internal.cc
+++ b/source/src/Internal.cc
@@ -313,7 +313,9 @@ namespace dqm4hep {
         stats[iname] = stat;
       }
       fclose(file);
-#endif // DQM4HEP_WITH_PROC_FS
+#else // DQM4HEP_WITH_PROC_FS
+    static void readLinuxNet(NetworkStats &/*stats*/) {
+#endif
     }
 
     //-------------------------------------------------------------------------------------------------

--- a/source/src/Internal.cc
+++ b/source/src/Internal.cc
@@ -204,7 +204,7 @@ namespace dqm4hep {
       fclose(f);
 
       stats.vmTot = (dqm_int)(memTotal + swap_total);
-      stats.vmUsed = (dqm_int)(memTotal - rssFree);
+      stats.vmUsed = (dqm_int)(memTotal - memFree);
       stats.vmFree = (dqm_int)(memFree + swap_free);
       stats.rssTot = (dqm_int)(memTotal);
       stats.rssUsed = (dqm_int)(memTotal - memFree);

--- a/source/src/Internal.cc
+++ b/source/src/Internal.cc
@@ -33,6 +33,7 @@
 
 #include <cstring>
 #include <dirent.h>
+#include <sys/resource.h>
 
 namespace dqm4hep {
 
@@ -281,7 +282,6 @@ namespace dqm4hep {
 #include <net/if.h>
 #include <net/if_dl.h>
 #include <net/route.h>
-#include <sys/resource.h>
 #include <sys/sysctl.h>
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/source/src/Internal.cc
+++ b/source/src/Internal.cc
@@ -309,6 +309,8 @@ namespace dqm4hep {
 
         if (EOF == fscanf(file, "%*[^\n]\n"))
           break;
+
+        stats[iname] = stat;
       }
       fclose(file);
 #endif // DQM4HEP_WITH_PROC_FS

--- a/source/src/Internal.cc
+++ b/source/src/Internal.cc
@@ -171,8 +171,8 @@ namespace dqm4hep {
       stats.vmTot = (dqm_int)(total + swap_total);
       stats.vmUsed = (dqm_int)(total - free);
       stats.vmFree = (dqm_int)(free + swap_free);
-      stats.rssTot = (dqm_int)(total >> 20);
-      stats.rssUsed = (dqm_int)((total - free) >> 20);
+      stats.rssTot = (dqm_int)(total);
+      stats.rssUsed = (dqm_int)((total - free));
     }
 
     //-------------------------------------------------------------------------------------------------

--- a/source/src/Internal.cc
+++ b/source/src/Internal.cc
@@ -237,6 +237,7 @@ namespace dqm4hep {
 
         // read received stats
         if (fscanf(file, "%lu %lu %lu", &stat.tot_rcv_kbytes, &stat.tot_rcv_packets, &stat.tot_rcv_errs) == EOF) {
+          stat.tot_rcv_kbytes = (dqm_int) ((stat.tot_rcv_kbytes) >> 10); // divide by 1024
           return;
         }
 
@@ -247,6 +248,7 @@ namespace dqm4hep {
 
         // read send stats
         if (fscanf(file, "%lu %lu %lu", &stat.tot_snd_kbytes, &stat.tot_snd_packets, &stat.tot_snd_errs) == EOF) {
+          stat.tot_snd_kbytes = (dqm_int) ((stat.tot_snd_kbytes) >> 10); // divide by 1024
           return;
         }
 

--- a/source/src/Internal.cc
+++ b/source/src/Internal.cc
@@ -210,8 +210,8 @@ namespace dqm4hep {
 
     //-------------------------------------------------------------------------------------------------
 
-    static void linuxNetStats(NetworkStats &stats) {
 #if defined(DQM4HEP_WITH_PROC_FS)
+    static void linuxNetStats(NetworkStats &stats, dqm_int /*sampleTime*/) {
       FILE *file = fopen("/proc/net/dev", "r");
 
       // skip first two lines

--- a/source/src/Internal.cc
+++ b/source/src/Internal.cc
@@ -236,7 +236,7 @@ namespace dqm4hep {
         INetworkStats stat;
 
         // read received stats
-        if (fscanf(file, "%lu %lu %lu", &stat.rcv_bytes, &stat.rcv_packets, &stat.rcv_errs) == EOF) {
+        if (fscanf(file, "%lu %lu %lu", &stat.tot_rcv_kbytes, &stat.tot_rcv_packets, &stat.tot_rcv_errs) == EOF) {
           return;
         }
 
@@ -246,7 +246,7 @@ namespace dqm4hep {
           break;
 
         // read send stats
-        if (fscanf(file, "%lu %lu %lu", &stat.snd_bytes, &stat.snd_packets, &stat.snd_errs) == EOF) {
+        if (fscanf(file, "%lu %lu %lu", &stat.tot_snd_kbytes, &stat.tot_snd_packets, &stat.tot_snd_errs) == EOF) {
           return;
         }
 

--- a/source/src/Internal.cc
+++ b/source/src/Internal.cc
@@ -265,7 +265,7 @@ namespace dqm4hep {
 
     //-------------------------------------------------------------------------------------------------
 
-    static void  readLinuxNet(NetworkStats &stats, dqm_int sampleTime) {
+    static void  readLinuxNet(NetworkStats &stats) {
 #if defined(DQM4HEP_WITH_PROC_FS)
       FILE *file = fopen("/proc/net/dev", "r");
 

--- a/source/src/Internal.cc
+++ b/source/src/Internal.cc
@@ -253,8 +253,17 @@ namespace dqm4hep {
         if (EOF == fscanf(file, "%*[^\n]\n"))
           break;
 
+      // TODO: Compute rate
+        stat.rcv_rate_kbytes = 0;
+        stat.rcv_rate_packets = 0;
+        stat.rcv_rate_errs = 0;
+        stat.snd_rate_kbytes = 0;
+        stat.snd_rate_packets = 0;
+        stat.snd_rate_errs = 0;
         stats[iname] = stat;
       }
+      // TODO: Compute rate, Warning displayed here to not pollute logs for each interface
+      dqm_warning("[{0}] - Network rate has not been implemented yet!", __FUNCTION__);
 
       fclose(file);
 #endif // DQM4HEP_WITH_PROC_FS

--- a/source/src/Internal.cc
+++ b/source/src/Internal.cc
@@ -40,6 +40,9 @@ namespace dqm4hep {
 
 #if defined(__linux__)
 
+// -- ROOT header
+#include <TPRegexp.h>
+
 #if defined(DQM4HEP_WITH_PROC_FS)
     // only for unix systems
     int getProcValue(const std::string fname, const std::string &entry) {
@@ -137,7 +140,6 @@ namespace dqm4hep {
         dqm_error("[{0}] - Failed to open '/proc/meminfo'", __FUNCTION__);
         throw core::StatusCodeException(STATUS_CODE_FAILURE);
       }
-      dqm_long_long used = {0LL};
       dqm_long_long free = {0LL};
       dqm_long_long total = {0LL};
 
@@ -164,7 +166,8 @@ namespace dqm4hep {
       }
       fclose(f);
 
-      stats.vmTot = (dqm_int)(total + swap_total) stats.vmUsed = (dqm_int)(total - free);
+      stats.vmTot = (dqm_int)(total + swap_total);
+      stats.vmUsed = (dqm_int)(total - free);
       stats.vmFree = (dqm_int)(free + swap_free);
       stats.rssTot = (dqm_int)(total >> 20);
       stats.rssUsed = (dqm_int)((total - free) >> 20);
@@ -254,9 +257,9 @@ namespace dqm4hep {
       }
 
       fclose(file);
+#endif // DQM4HEP_WITH_PROC_FS
     }
 
-#endif // DQM4HEP_WITH_PROC_FS
 #endif // __linux__
 
     //---- System, CPU and Memory info ---------------------------------------------
@@ -414,7 +417,6 @@ namespace dqm4hep {
 
       struct rusage ru;
       if (getrusage(RUSAGE_SELF, &ru) < 0) {
-        // ::SysError("darwinProcStats", "getrusage failed");
         dqm_error("[{0}] - Failed to getrusage", __FUNCTION__);
         throw core::StatusCodeException(STATUS_CODE_FAILURE);
       } else {
@@ -435,7 +437,6 @@ namespace dqm4hep {
 
       kern_return_t kr = task_info(a_task, TASK_BASIC_INFO, (task_info_t)&ti, &count);
       if (kr != KERN_SUCCESS) {
-        // ::Error("darwinProcStats", "task_info: %s", mach_error_string(kr));
         dqm_error("[{0}] - Failed to get task_info: {1}", __FUNCTION__, mach_error_string(kr));
         throw core::StatusCodeException(STATUS_CODE_FAILURE);
       } else {

--- a/source/src/Internal.cc
+++ b/source/src/Internal.cc
@@ -184,7 +184,7 @@ namespace dqm4hep {
         stats.cpuTimeSys = (dqm_float)(ru.ru_stime.tv_sec) + ((dqm_float)(ru.ru_stime.tv_usec) / 1000000.);
 
         //  TODO: Compute proc cpu load here
-        dqm_warning(__FUNCTION__, " Process cpu load has not been implemented yet!");
+        dqm_warning("[{0}] - Process cpu load has not been implemented yet!", __FUNCTION__);
         stats.cpuUser = -1;
         stats.cpuSys = -1;
         stats.cpuTot = -1;
@@ -422,7 +422,7 @@ namespace dqm4hep {
         stats.cpuTimeSys = (dqm_float)(ru.ru_stime.tv_sec) + ((dqm_float)(ru.ru_stime.tv_usec) / 1000000.);
 
         //TODO: Compute proc cpu load here
-        dqm_warning(__FUNCTION__, " Process cpu load has not been implemented yet!");
+        dqm_warning("[{0}] - Process cpu load has not been implemented yet!", __FUNCTION__);
         stats.cpuUser = -1;
         stats.cpuSys = -1;
         stats.cpuTot = -1;
@@ -612,7 +612,7 @@ namespace dqm4hep {
 #if defined(_WIN32)
     static void winCpuStats(CpuStats &stats, dqm_int sampleTime){
       /* WINDOWS implementation: TBD */
-      dqm_warning(__FUNCTION__, " has not been implemented!");
+      dqm_warning("[{0}] - has not been implemented!", __FUNCTION__);
       throw core::StatusCodeException(STATUS_CODE_NOT_FOUND);
     }
 
@@ -620,7 +620,7 @@ namespace dqm4hep {
 
     static void winMemStats(MemoryStats &stats) {
       /* WINDOWS implementation: TBD */
-      dqm_warning(__FUNCTION__, " has not been implemented!");
+      dqm_warning("[{0}] - has not been implemented!", __FUNCTION__);
       throw core::StatusCodeException(STATUS_CODE_NOT_FOUND);
     }
 
@@ -628,7 +628,7 @@ namespace dqm4hep {
 
     static void winProcStats(ProcessStats &stats) {
       /* WINDOWS implementation: TBD */
-      dqm_warning(__FUNCTION__, " has not been implemented!");
+      dqm_warning("[{0}] - has not been implemented!", __FUNCTION__);
       throw core::StatusCodeException(STATUS_CODE_NOT_FOUND);
     }
 
@@ -636,7 +636,7 @@ namespace dqm4hep {
 
     static void winNetStats(NetworkStats &stats, dqm_int sampleTime) {
       /* WINDOWS implementation: TBD */
-      dqm_warning(__FUNCTION__, " has not been implemented!");
+      dqm_warning("[{0}] - has not been implemented!", __FUNCTION__);
       throw core::StatusCodeException(STATUS_CODE_NOT_FOUND);
     }
 

--- a/source/src/Internal.cc
+++ b/source/src/Internal.cc
@@ -28,27 +28,33 @@
 #include <dqm4hep/Internal.h>
 #include <dqm4hep/Logging.h> // Include here to avoid cycling include in the header
 
+// -- ROOT header
+#include <TSystem.h>
+
 #include <cstring>
+#include <dirent.h>
 
 namespace dqm4hep {
 
   namespace core {
 
-#ifdef DQM4HEP_WITH_PROC_FS
+#if defined(__linux__)
+
+#if defined(DQM4HEP_WITH_PROC_FS)
     // only for unix systems
     int getProcValue(const std::string fname, const std::string &entry) {
-      FILE* file = fopen(fname.c_str(), "r");
+      FILE *file = fopen(fname.c_str(), "r");
       int result = -1;
       char line[128];
 
       while (fgets(line, 128, file) != nullptr) {
         if (strncmp(line, entry.c_str(), entry.size()) == 0) {
           int i = strlen(line);
-          const char* p = line;
-          while (*p <'0' || *p > '9') {
+          const char *p = line;
+          while (*p < '0' || *p > '9') {
             p++;
           }
-          line[i-3] = '\0';
+          line[i - 3] = '\0';
           result = atoi(p);
           break;
         }
@@ -56,201 +62,647 @@ namespace dqm4hep {
       fclose(file);
       return result;
     }
-#endif
+#endif // DQM4HEP_WITH_PROC_FS
 
-#ifdef _WIN32
-    void memStats(MemoryStats &) {
-      /* WINDOWS implementation: TBD */
-    }
-    
     //-------------------------------------------------------------------------------------------------
-    
-    void netStats(NetworkStats &stats) {
-      /* WINDOWS implementation: TBD */
+    /// Read CPU load on Linux.
+
+    static void readLinuxCpu(long *ticks) {
+      ticks[0] = ticks[1] = ticks[2] = ticks[3] = 0;
+
+      TString s;
+      FILE *f = fopen("/proc/stat", "r");
+
+      if (!f) {
+        dqm_error("[{0}] - Failed to open '/proc/stat'", __FUNCTION__);
+        throw core::StatusCodeException(STATUS_CODE_FAILURE);
+      }
+
+      s.Gets(f);
+      // user, user nice, sys, idle
+      sscanf(s.Data(), "%*s %ld %ld %ld %ld", &ticks[0], &ticks[3], &ticks[1], &ticks[2]);
+      fclose(f);
     }
-#elif __APPLE__
-    void memStats(MemoryStats &stats) {
-      double unit = 1024. * 1024.; // Store everything in mb
 
-      // Swap info
-      // Retrieved in Bytes
-      struct xsw_usage swapStats;
-      size_t lengthSwap = sizeof(swapStats);
-      if (KERN_SUCCESS != sysctlbyname("vm.swapusage", &swapStats, &lengthSwap, NULL, 0))
-      {
-        dqm_error("[{0}] - Failed to get swap statistics.", __FUNCTION__);
-        throw core::StatusCodeException(STATUS_CODE_FAILURE);
-      }
-
-      // Total physical memory
-      // Retrieved in Bytes
-      int64_t physicalMem;
-      size_t lengthPM = sizeof(physicalMem);
-      if (KERN_SUCCESS != sysctlbyname("hw.memsize", &physicalMem, &lengthPM, NULL, 0))
-      {
-        dqm_error("[{0}] - Failed to get physical memory statistics.", __FUNCTION__);
-        throw core::StatusCodeException(STATUS_CODE_FAILURE);
-      }
-      stats.rsstot = physicalMem;
-      stats.rsstot /= unit;
-
-      // Total virtual memory
-      stats.vmtot = physicalMem + swapStats.xsu_total;
-      stats.vmtot /= unit;
-
-      // Used Physical/Virtual Memory 
-      // Retrieved in number of pages
-      int pageSize;
-      size_t lengthPage = sizeof(pageSize);
-      if (KERN_SUCCESS != sysctlbyname("hw.pagesize", &pageSize, &lengthPage, NULL, 0))
-      {
-        dqm_error("[{0}] - Failed to get page size.", __FUNCTION__);
-        throw core::StatusCodeException(STATUS_CODE_FAILURE);
-      }
-      vm_statistics_data_t vmStat;
-      mach_msg_type_number_t vmInfoCount = HOST_VM_INFO_COUNT;
-      if (KERN_SUCCESS != host_statistics (mach_host_self (), HOST_VM_INFO, (host_info_t) &vmStat, &vmInfoCount))
-      {
-        dqm_error("[{0}] - Failed to get VM statistics.", __FUNCTION__);
-        throw core::StatusCodeException(STATUS_CODE_FAILURE);
-      }
-      double wired = vmStat.wire_count; // In use, cannot go inactive
-      double active = vmStat.active_count; // Currently in use, can go inactive if not accessed for some time
-      double inactive = vmStat.inactive_count; // Was in use not long ago, still retrievable -> Not Sure wheter to include in used ram
-      double free = vmStat.free_count; // Real free ram usable instantly -> Always around 0-50mb max on my mac
-      double total = wired + active + inactive;
-
-      stats.rssused = (total - free) * pageSize;
-      stats.vmused = stats.rssused + swapStats.xsu_used;
-      stats.rssused /= unit;
-      stats.vmused /= unit;
-
-
-      // Process virtual and physical memory size
-      // Retrieved in Bytes
-      // Physical memory in this case is the actual memory taken by the process
-      // Virtual memory: Most processes are assigned ~4Go of virtual mem whether they use it or not. No idea what is governing this, or the real meaning of it.
-      struct task_basic_info_64 taskInfo;
-      mach_msg_type_number_t taskInfoCount = TASK_BASIC_INFO_64_COUNT;
-      if (KERN_SUCCESS != task_info(mach_task_self(), TASK_BASIC_INFO_64, (task_info_t) &taskInfo, &taskInfoCount))
-      {
-        dqm_error("[{0}] - Failed to get process memory statistics.", __FUNCTION__);
-        throw core::StatusCodeException(STATUS_CODE_FAILURE);
-      }
-      stats.rssproc = taskInfo.resident_size;
-      stats.rssproc /= unit;
-      stats.vmproc = taskInfo.resident_size; // Display physical size, as virtual_size is meaningless in this context
-      stats.vmproc /= unit;
-    }
-    
     //-------------------------------------------------------------------------------------------------
-    
-    void netStats(NetworkStats &stats) {
-      /* MACOSX implementation: TBD */
-    }
-#elif __linux__ || defined(_POSIX_VERSION)
-    void memStats(MemoryStats &stats) {
-      struct sysinfo memInfo;
-      sysinfo (&memInfo);
-      
-      // total virtual memory
-      stats.vmtot = memInfo.totalram;
-      stats.vmtot += memInfo.totalswap;
-      stats.vmtot *= memInfo.mem_unit;
-      stats.vmtot /= (1024.*1024.);
+    /// Get CPU stat for Linux. Use sampleTime to set the interval over which
+    /// the CPU load will be measured, in s (default 1).
 
-      // total virtual memory in use
-      stats.vmused = memInfo.totalram - memInfo.freeram;
-      stats.vmused += memInfo.totalswap - memInfo.freeswap;
-      stats.vmused *= memInfo.mem_unit;
-      stats.vmused /= (1024.*1024.);
-            
-      // Total physical memory
-      stats.rsstot = memInfo.totalram;
-      stats.rsstot *= memInfo.mem_unit;
-      stats.rsstot /= (1024.*1024.);
-      
-      // Total physical memory in use
-      stats.rssused = memInfo.totalram - memInfo.freeram;
-      stats.rssused *= memInfo.mem_unit;
-      stats.rssused /= (1024.*1024.);
-      
-      // Process virtual memory size and physical memory size
-      std::stringstream procstat; procstat << "/proc/" << core::pid() << "/status";
-      stats.vmproc = getProcValue(procstat.str().c_str(), "VmSize:")/(1024.);
-      stats.rssproc = getProcValue(procstat.str().c_str(), "VmRSS:")/(1024.);
+    static void linuxCpuStats(CpuStats &stats, dqm_int sampleTime) {
+      dqm_double avg[3] = {-1.};
+#ifndef R__WINGCC
+      if (getloadavg(avg, sizeof(avg)) < 0) {
+        // ::Error("getLinuxCpuInfo", "getloadavg failed");
+        dqm_error("[{0}] - Failed to getloadavg'", __FUNCTION__);
+        throw core::StatusCodeException(STATUS_CODE_FAILURE);
+      } else
+#endif // R__WINGCC
+      {
+        stats.load1m = (dqm_float)avg[0];
+        stats.load5m = (dqm_float)avg[1];
+        stats.load15m = (dqm_float)avg[2];
+      }
+
+      dqm_long cpu_ticks1[4] = {0L};
+      dqm_long cpu_ticks2[4] = {0L};
+      readLinuxCpu(cpu_ticks1);
+      ::sleep(sampleTime);
+      readLinuxCpu(cpu_ticks2);
+
+      dqm_long userticks = (cpu_ticks2[0] + cpu_ticks2[3]) - (cpu_ticks1[0] + cpu_ticks1[3]);
+      dqm_long systicks = cpu_ticks2[1] - cpu_ticks1[1];
+      dqm_long idleticks = cpu_ticks2[2] - cpu_ticks1[2];
+      if (userticks < 0)
+        userticks = 0;
+      if (systicks < 0)
+        systicks = 0;
+      if (idleticks < 0)
+        idleticks = 0;
+      dqm_long totalticks = userticks + systicks + idleticks;
+      if (totalticks) {
+        stats.user = ((dqm_float)(100 * userticks)) / ((dqm_float)totalticks);
+        stats.sys = ((dqm_float)(100 * systicks)) / ((dqm_float)totalticks);
+        stats.tot = stats.user + stats.sys;
+        stats.idle = ((dqm_float)(100 * idleticks)) / ((dqm_float)totalticks);
+      }
     }
-    
+
     //-------------------------------------------------------------------------------------------------
-    
-    void netStats(NetworkStats &stats) {
-#ifdef DQM4HEP_WITH_PROC_FS
-      FILE* file = fopen("/proc/net/dev", "r");
-      
+    /// Get VM stat for Linux.
+
+    static void linuxMemStats(MemoryStats &stats) {
+      TString s;
+      FILE *f = fopen("/proc/meminfo", "r");
+      if (!f) {
+        dqm_error("[{0}] - Failed to open '/proc/meminfo'", __FUNCTION__);
+        throw core::StatusCodeException(STATUS_CODE_FAILURE);
+      }
+      dqm_long_long used = {0LL};
+      dqm_long_long free = {0LL};
+      dqm_long_long total = {0LL};
+
+      dqm_long_long swap_total = {0LL};
+      dqm_long_long swap_free = {0LL};
+
+      while (s.Gets(f)) {
+        if (s.BeginsWith("MemTotal")) {
+          TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
+          total = (s.Atoi() / 1024);
+        }
+        if (s.BeginsWith("MemFree")) {
+          TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
+          free = (s.Atoi() / 1024);
+        }
+        if (s.BeginsWith("SwapTotal")) {
+          TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
+          swap_total = (s.Atoi() / 1024);
+        }
+        if (s.BeginsWith("SwapFree")) {
+          TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
+          swap_free = (s.Atoi() / 1024);
+        }
+      }
+      fclose(f);
+
+      stats.vmTot = (dqm_int)(total + swap_total) stats.vmUsed = (dqm_int)(total - free);
+      stats.vmFree = (dqm_int)(free + swap_free);
+      stats.rssTot = (dqm_int)(total >> 20);
+      stats.rssUsed = (dqm_int)((total - free) >> 20);
+    }
+
+    //-------------------------------------------------------------------------------------------------
+    /// Get process info for this process on Linux.
+
+    static void linuxProcStats(ProcessStats &stats) {
+      struct rusage ru;
+      if (getrusage(RUSAGE_SELF, &ru) < 0) {
+        // ::SysError("getLinuxProcInfo", "getrusage failed");
+        dqm_error("[{0}] - Failed to getrusage", __FUNCTION__);
+        throw core::StatusCodeException(STATUS_CODE_FAILURE);
+      } else {
+        stats.cpuTimeUser = (dqm_float)(ru.ru_utime.tv_sec) + ((dqm_float)(ru.ru_utime.tv_usec) / 1000000.);
+        stats.cpuTimeSys = (dqm_float)(ru.ru_stime.tv_sec) + ((dqm_float)(ru.ru_stime.tv_usec) / 1000000.);
+
+        //  TODO: Compute proc cpu load here
+        dqm_warning(__FUNCTION__, " Process cpu load has not been implemented yet!");
+        stats.cpuUser = -1;
+        stats.cpuSys = -1;
+        stats.cpuTot = -1;
+      }
+
+      stats.vm = -1;
+      stats.rss = -1;
+      TString s;
+      FILE *f = fopen(TString::Format("/proc/%d/statm", gSystem->GetPid()), "r");
+      if (f) {
+        s.Gets(f);
+        fclose(f);
+        dqm_long total = {0L};
+        dqm_long rss = {0L};
+        sscanf(s.Data(), "%ld %ld", &total, &rss);
+        stats.vm = total * (getpagesize() / 1024);
+        stats.rss = rss * (getpagesize() / 1024);
+      }
+    }
+
+    //-------------------------------------------------------------------------------------------------
+
+    static void linuxNetStats(NetworkStats &stats) {
+#if defined(DQM4HEP_WITH_PROC_FS)
+      FILE *file = fopen("/proc/net/dev", "r");
+
       // skip first two lines
-      if(fscanf(file, "%*[^\n]\n") == EOF or fscanf(file, "%*[^\n]\n") == EOF) {
+      if (fscanf(file, "%*[^\n]\n") == EOF or fscanf(file, "%*[^\n]\n") == EOF) {
         return;
       }
 
-      while(1) {
+      while (1) {
         // get interface name
         std::string iname;
-        char c; 
+        char c;
         do {
           c = fgetc(file);
-          if(c == ':')
+          if (c == ':')
             break;
           iname += c;
-        }
-        while(c != EOF && c != '\n');
-        
-        if(c == EOF)
+        } while (c != EOF && c != '\n');
+
+        if (c == EOF)
           break;
-        
+
         INetworkStats stat;
-        
+
         // read received stats
-        if(fscanf(file, "%lu %lu %lu", 
-          &stat.rcv_bytes, 
-          &stat.rcv_packets, 
-          &stat.rcv_errs) == EOF) {
-            return;
-          }
-        
+        if (fscanf(file, "%lu %lu %lu", &stat.rcv_bytes, &stat.rcv_packets, &stat.rcv_errs) == EOF) {
+          return;
+        }
+
         // skip uneeded fields
         dqm_stat dummy;
-        if(EOF == fscanf(file, "%lu %lu %lu %lu %lu", &dummy, &dummy, &dummy, &dummy, &dummy))
-            break;
-        
-        // read send stats
-        if(fscanf(file, "%lu %lu %lu", 
-          &stat.snd_bytes,
-          &stat.snd_packets,
-          &stat.snd_errs) == EOF) {
-            return;
-          }
-        
-        if(EOF == fscanf(file, "%*[^\n]\n"))
+        if (EOF == fscanf(file, "%lu %lu %lu %lu %lu", &dummy, &dummy, &dummy, &dummy, &dummy))
           break;
-        
+
+        // read send stats
+        if (fscanf(file, "%lu %lu %lu", &stat.snd_bytes, &stat.snd_packets, &stat.snd_errs) == EOF) {
+          return;
+        }
+
+        if (EOF == fscanf(file, "%*[^\n]\n"))
+          break;
+
         stats[iname] = stat;
       }
-      
+
       fclose(file);
-#endif
     }
-#elif __unix__
-    void memStats(MemoryStats &) {
-      /* UNIX implementation: TBD */
+
+#endif // DQM4HEP_WITH_PROC_FS
+#endif // __linux__
+
+    //---- System, CPU and Memory info ---------------------------------------------
+
+#if defined(__APPLE__)
+#include <mach/mach.h>
+#include <mach/mach_error.h>
+#include <net/if.h>
+#include <net/if_dl.h>
+#include <net/route.h>
+#include <sys/resource.h>
+#include <sys/sysctl.h>
+
+    ////////////////////////////////////////////////////////////////////////////////
+    /// Get CPU load on Mac OS X.
+
+    static void readDarwinCpu(long *ticks) {
+      ticks[0] = ticks[1] = ticks[2] = ticks[3] = 0;
+
+      host_cpu_load_info_data_t cpu;
+      mach_msg_type_number_t count = HOST_CPU_LOAD_INFO_COUNT;
+
+      kern_return_t kr = host_statistics(mach_host_self(), HOST_CPU_LOAD_INFO, (host_info_t)&cpu, &count);
+      if (kr != KERN_SUCCESS) {
+        dqm_error("[{0}] - Failed to get host_statistics: {1}", __FUNCTION__, mach_error_string(kr));
+        throw core::StatusCodeException(STATUS_CODE_FAILURE);
+      } else {
+        ticks[0] = cpu.cpu_ticks[CPU_STATE_USER];
+        ticks[1] = cpu.cpu_ticks[CPU_STATE_SYSTEM];
+        ticks[2] = cpu.cpu_ticks[CPU_STATE_IDLE];
+        ticks[3] = cpu.cpu_ticks[CPU_STATE_NICE];
+      }
     }
-    
+
+    ////////////////////////////////////////////////////////////////////////////////
+    /// Get CPU stat for Mac OS X. Use sampleTime to set the interval over which
+    /// the CPU load will be measured, in s (default 1).
+
+    static void darwinCpuStats(CpuStats &stats, dqm_int sampleTime) {
+      dqm_double avg[3] = {-1.};
+      if (getloadavg(avg, sizeof(avg)) < 0) {
+        // ::Error("darwinCpuStats", "getloadavg failed");
+        dqm_error("[{0}] - Failed to getloadavg", __FUNCTION__);
+        throw core::StatusCodeException(STATUS_CODE_FAILURE);
+      } else {
+        stats.load1m = (dqm_float)avg[0];
+        stats.load5m = (dqm_float)avg[1];
+        stats.load15m = (dqm_float)avg[2];
+      }
+
+      dqm_long cpu_ticks1[4] = {0L};
+      dqm_long cpu_ticks2[4] = {0L};
+      readDarwinCpu(cpu_ticks1);
+      ::sleep(sampleTime);
+      readDarwinCpu(cpu_ticks2);
+
+      dqm_long userticks = (cpu_ticks2[0] + cpu_ticks2[3]) - (cpu_ticks1[0] + cpu_ticks1[3]);
+      dqm_long systicks = cpu_ticks2[1] - cpu_ticks1[1];
+      dqm_long idleticks = cpu_ticks2[2] - cpu_ticks1[2];
+      if (userticks < 0)
+        userticks = 0;
+      if (systicks < 0)
+        systicks = 0;
+      if (idleticks < 0)
+        idleticks = 0;
+      dqm_long totalticks = userticks + systicks + idleticks;
+      if (totalticks) {
+        stats.user = ((dqm_float)(100 * userticks)) / ((dqm_float)totalticks);
+        stats.sys = ((dqm_float)(100 * systicks)) / ((dqm_float)totalticks);
+        stats.tot = stats.user + stats.sys;
+        stats.idle = ((dqm_float)(100 * idleticks)) / ((dqm_float)totalticks);
+      }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+    /// Get VM stat for Mac OS X.
+
+    static void darwinMemStats(MemoryStats &stats) {
+      vm_statistics_data_t vm_info;
+      mach_msg_type_number_t count = HOST_VM_INFO_COUNT;
+
+      kern_return_t kr = host_statistics(mach_host_self(), HOST_VM_INFO, (host_info_t)&vm_info, &count);
+      if (kr != KERN_SUCCESS) {
+        // ::Error("getDarwinMemInfo", "host_statistics: %s", mach_error_string(kr));
+        dqm_error("[{0}] - Failed to get host_statistics: {1}", __FUNCTION__, mach_error_string(kr));
+        throw core::StatusCodeException(STATUS_CODE_FAILURE);
+      }
+      static dqm_int pshift = 0;
+      if (pshift == 0) {
+        for (int psize = getpagesize(); psize > 1; psize >>= 1) {
+          pshift++;
+        }
+      }
+
+      dqm_long_long used = (dqm_long_long)(vm_info.active_count + vm_info.inactive_count + vm_info.wire_count)
+                           << pshift;
+      dqm_long_long free = (dqm_long_long)(vm_info.free_count) << pshift;
+      dqm_long_long total =
+          (dqm_long_long)(vm_info.active_count + vm_info.inactive_count + vm_info.free_count + vm_info.wire_count)
+          << pshift;
+
+      // Swap is available at same time as mem, so grab values here.
+      dqm_long_long swap_used = vm_info.pageouts << pshift;
+
+      // Figure out total swap. This adds up the size of the swapfiles */
+      static DIR *dirp = nullptr;
+      dirp = opendir("/private/var/vm");
+      if (!dirp) {
+        dqm_error("[{0}] - Failed to get vm file", __FUNCTION__);
+        throw core::StatusCodeException(STATUS_CODE_FAILURE);
+        // return;
+      }
+
+      dqm_long_long swap_total = 0;
+      struct dirent *dp = nullptr;
+
+      while ((dp = readdir(dirp)) != 0) {
+        struct stat sb;
+        char fname[MAXNAMLEN];
+        if (strncmp(dp->d_name, "swapfile", 8))
+          continue;
+        strlcpy(fname, "/private/var/vm/", MAXNAMLEN);
+        strlcat(fname, dp->d_name, MAXNAMLEN);
+        if (stat(fname, &sb) < 0)
+          continue;
+        swap_total += sb.st_size;
+      }
+      closedir(dirp);
+
+      stats.vmTot = (dqm_int)((total + swap_total) >> 20); // divide by 1024 * 1024
+      stats.vmUsed = (dqm_int)((used + swap_used) >> 20);
+      stats.vmFree = (dqm_int)((free + swap_total - swap_used) >> 20);
+      stats.rssTot = (dqm_int)(total >> 20);
+      stats.rssUsed = (dqm_int)(used >> 20);
+    }
+
     //-------------------------------------------------------------------------------------------------
-    
-    void netStats(NetworkStats &stats) {
-      /* UNIX implementation: TBD */
+    /// Get process info for this process on Mac OS X.
+    /// Code largely taken from:
+    /// http://www.opensource.apple.com/source/top/top-15/libtop.c
+    /// The virtual memory usage is slightly over estimated as we don't
+    /// subtract shared regions, but the value makes more sense
+    /// then pure vsize, which is useless on 64-bit machines.
+
+    static void darwinProcStats(ProcessStats &stats) {
+#ifdef _LP64
+#define vm_region vm_region_64
+#endif
+
+// taken from <mach/shared_memory_server.h> which is obsoleted in 10.5
+#define GLOBAL_SHARED_TEXT_SEGMENT 0x90000000U
+#define GLOBAL_SHARED_DATA_SEGMENT 0xA0000000U
+#define SHARED_TEXT_REGION_SIZE 0x10000000
+#define SHARED_DATA_REGION_SIZE 0x10000000
+
+      struct rusage ru;
+      if (getrusage(RUSAGE_SELF, &ru) < 0) {
+        // ::SysError("darwinProcStats", "getrusage failed");
+        dqm_error("[{0}] - Failed to getrusage", __FUNCTION__);
+        throw core::StatusCodeException(STATUS_CODE_FAILURE);
+      } else {
+        stats.cpuTimeUser = (dqm_float)(ru.ru_utime.tv_sec) + ((dqm_float)(ru.ru_utime.tv_usec) / 1000000.);
+        stats.cpuTimeSys = (dqm_float)(ru.ru_stime.tv_sec) + ((dqm_float)(ru.ru_stime.tv_usec) / 1000000.);
+
+        //TODO: Compute proc cpu load here
+        dqm_warning(__FUNCTION__, " Process cpu load has not been implemented yet!");
+        stats.cpuUser = -1;
+        stats.cpuSys = -1;
+        stats.cpuTot = -1;
+
+      }
+
+      task_t a_task = mach_task_self();
+      task_basic_info_data_t ti;
+      mach_msg_type_number_t count = TASK_BASIC_INFO_COUNT;
+
+      kern_return_t kr = task_info(a_task, TASK_BASIC_INFO, (task_info_t)&ti, &count);
+      if (kr != KERN_SUCCESS) {
+        // ::Error("darwinProcStats", "task_info: %s", mach_error_string(kr));
+        dqm_error("[{0}] - Failed to get task_info: {1}", __FUNCTION__, mach_error_string(kr));
+        throw core::StatusCodeException(STATUS_CODE_FAILURE);
+      } else {
+        // resident size does not require any calculation. Virtual size
+        // needs to be adjusted if traversing memory objects do not include the
+        // globally shared text and data regions
+        mach_port_t object_name;
+        vm_address_t address;
+        vm_region_top_info_data_t info;
+
+        vm_size_t rsize = ti.resident_size;
+        vm_size_t vsize = ti.virtual_size;
+        vm_size_t vprvt = 0;
+        vm_size_t size = 0;
+
+        for (address = 0;; address += size) {
+          // get memory region
+          count = VM_REGION_TOP_INFO_COUNT;
+          if (vm_region(a_task, &address, &size, VM_REGION_TOP_INFO, (vm_region_info_t)&info, &count, &object_name) !=
+              KERN_SUCCESS) {
+            // no more memory regions.
+            break;
+          }
+
+          if (address >= GLOBAL_SHARED_TEXT_SEGMENT &&
+              address < (GLOBAL_SHARED_DATA_SEGMENT + SHARED_DATA_REGION_SIZE)) {
+            // This region is private shared.
+            // Check if this process has the globally shared
+            // text and data regions mapped in. If so, adjust
+            // virtual memory size and exit loop.
+            if (info.share_mode == SM_EMPTY) {
+              vm_region_basic_info_data_64_t b_info;
+              count = VM_REGION_BASIC_INFO_COUNT_64;
+              if (vm_region_64(a_task, &address, &size, VM_REGION_BASIC_INFO, (vm_region_info_t)&b_info, &count,
+                               &object_name) != KERN_SUCCESS) {
+                break;
+              }
+
+              if (b_info.reserved) {
+                vsize -= (SHARED_TEXT_REGION_SIZE + SHARED_DATA_REGION_SIZE);
+                // break;  // only for vsize
+              }
+            }
+            // Short circuit the loop if this isn't a shared
+            // private region, since that's the only region
+            // type we care about within the current address range.
+            if (info.share_mode != SM_PRIVATE) {
+              continue;
+            }
+          }
+          switch (info.share_mode) {
+          case SM_COW: {
+            if (info.ref_count == 1) {
+              vprvt += size;
+            } else {
+              vprvt += info.private_pages_resident * getpagesize();
+            }
+            break;
+          }
+          case SM_PRIVATE: {
+            vprvt += size;
+            break;
+          }
+          default:
+            break;
+          }
+        }
+
+        stats.vm = (dqm_long)(rsize / 1024.);
+        stats.rss = (dqm_long)(vprvt / 1024.);
+      }
     }
+
+    //-------------------------------------------------------------------------------------------------
+    static void readDarwinNet(NetworkStats &stats) {
+      double unit = 1024.; // Store everything in kb
+
+      // Get sizing info from sysctl and resize as needed.
+      int mib[] = {CTL_NET, PF_ROUTE, 0, 0, NET_RT_IFLIST, 0};
+      size_t currentSize{0};
+      if (sysctl(mib, 6, NULL, &currentSize, NULL, 0) != 0) {
+        const int errNum = errno;
+        dqm_error("[{0}] - Failed to get network buffer size: {1}", __FUNCTION__, errNum);
+        throw core::StatusCodeException(STATUS_CODE_FAILURE);
+      }
+      size_t sysctlBufferSize{0};
+      uint8_t *sysctlBuffer = nullptr;
+      if (!sysctlBuffer || (currentSize > sysctlBufferSize)) {
+        if (sysctlBuffer)
+          free(sysctlBuffer);
+        sysctlBufferSize = 0;
+        sysctlBuffer = (uint8_t *)malloc(currentSize);
+        if (!sysctlBuffer) {
+          const int errNum = errno;
+          dqm_error("[{0}] - Failed to get network statistics: {1}", __FUNCTION__, errNum);
+          throw core::StatusCodeException(STATUS_CODE_FAILURE);
+        }
+        sysctlBufferSize = currentSize;
+      }
+
+      // Read in new data
+      if (sysctl(mib, 6, sysctlBuffer, &currentSize, NULL, 0) != 0) {
+        const int errNum = errno;
+        dqm_error("[{0}] - Failed to read network statistics: {1}", __FUNCTION__, errNum);
+        throw core::StatusCodeException(STATUS_CODE_FAILURE);
+      }
+
+      // Walk through the reply
+      uint8_t *currentData = sysctlBuffer;
+      uint8_t *currentDataEnd = sysctlBuffer + currentSize;
+
+      while (currentData < currentDataEnd) {
+        // Expecting interface data
+        struct if_msghdr *ifmsg = (struct if_msghdr *)currentData;
+        if (ifmsg->ifm_type != RTM_IFINFO) {
+          currentData += ifmsg->ifm_msglen;
+          continue;
+        }
+
+        // Only look at link layer items
+        struct sockaddr_dl *sdl = (struct sockaddr_dl *)(ifmsg + 1);
+        if (sdl->sdl_family != AF_LINK) {
+          currentData += ifmsg->ifm_msglen;
+          continue;
+        }
+
+        // Get interface name
+        char ifc_name[32];
+        strncpy(ifc_name, sdl->sdl_data, sdl->sdl_nlen);
+        ifc_name[sdl->sdl_nlen] = 0;
+
+        INetworkStats stat;
+        stat.tot_rcv_kbytes = ifmsg->ifm_data.ifi_ibytes / unit;
+        stat.tot_rcv_packets = ifmsg->ifm_data.ifi_ipackets;
+        stat.tot_rcv_errs = ifmsg->ifm_data.ifi_ierrors;
+        stat.tot_snd_kbytes = ifmsg->ifm_data.ifi_obytes / unit;
+        stat.tot_snd_packets = ifmsg->ifm_data.ifi_opackets;
+        stat.tot_snd_errs = ifmsg->ifm_data.ifi_oerrors;
+        stats[ifc_name] = stat;
+
+        currentData += ifmsg->ifm_msglen;
+      }
+    }
+    static void darwinNetStats(NetworkStats &stats, dqm_int sampleTime) {
+
+      NetworkStats tempStats;
+      readDarwinNet(tempStats);
+      ::sleep(sampleTime);
+      readDarwinNet(stats);
+
+      for (const auto &ifcIter : tempStats) {
+        auto ifcIter2 = stats.find(ifcIter.first);
+
+        if (ifcIter.first != ifcIter2->first) {
+          dqm_error("[{0}] - Wrong interface comparison");
+          throw core::StatusCodeException(STATUS_CODE_FAILURE);
+        }
+
+        ifcIter2->second.rcv_rate_kbytes =
+            (ifcIter2->second.tot_rcv_kbytes - ifcIter.second.tot_rcv_kbytes) / sampleTime;
+        ifcIter2->second.rcv_rate_packets =
+            (ifcIter2->second.tot_rcv_packets - ifcIter.second.tot_rcv_packets) / sampleTime;
+        ifcIter2->second.rcv_rate_errs = (ifcIter2->second.tot_rcv_errs - ifcIter.second.tot_rcv_errs) / sampleTime;
+        ifcIter2->second.snd_rate_kbytes =
+            (ifcIter2->second.tot_snd_kbytes - ifcIter.second.tot_snd_kbytes) / sampleTime;
+        ifcIter2->second.snd_rate_packets =
+            (ifcIter2->second.tot_snd_packets - ifcIter.second.tot_snd_packets) / sampleTime;
+        ifcIter2->second.snd_rate_errs = (ifcIter2->second.tot_snd_errs - ifcIter.second.tot_snd_errs) / sampleTime;
+      }
+    }
+
+#endif // __APPLE__
+
+#if defined(_WIN32)
+    static void winCpuStats(CpuStats &stats, dqm_int sampleTime){
+      /* WINDOWS implementation: TBD */
+      dqm_warning(__FUNCTION__, " has not been implemented!");
+      throw core::StatusCodeException(STATUS_CODE_NOT_FOUND);
+    }
+
+    //-------------------------------------------------------------------------------------------------
+
+    static void winMemStats(MemoryStats &stats) {
+      /* WINDOWS implementation: TBD */
+      dqm_warning(__FUNCTION__, " has not been implemented!");
+      throw core::StatusCodeException(STATUS_CODE_NOT_FOUND);
+    }
+
+    //-------------------------------------------------------------------------------------------------
+
+    static void winProcStats(ProcessStats &stats) {
+      /* WINDOWS implementation: TBD */
+      dqm_warning(__FUNCTION__, " has not been implemented!");
+      throw core::StatusCodeException(STATUS_CODE_NOT_FOUND);
+    }
+
+    //-------------------------------------------------------------------------------------------------
+
+    static void winNetStats(NetworkStats &stats, dqm_int sampleTime) {
+      /* WINDOWS implementation: TBD */
+      dqm_warning(__FUNCTION__, " has not been implemented!");
+      throw core::StatusCodeException(STATUS_CODE_NOT_FOUND);
+    }
+
+
+#endif //_WIN32
+
+    //-------------------------------------------------------------------------------------------------
+    /// Returns cpu load average and load info into the CpuInfo_t structure.
+    /// Use sampleTime to set the interval over which the CPU load will be measured,
+    /// In ms (default 1000).
+
+    void cpuStats(CpuStats &stats, dqm_int sampleTime) {
+#if defined(__APPLE__)
+      darwinCpuStats(stats, sampleTime);
+#elif defined(__linux__)
+      linuxCpuStats(stats, sampleTime);
+#elif defined(_WIN32)
+      winCpuStats(stats, sampleTime);
 #else
 #error "Unrecognized OS plateform (not windows, linux, OSX or unix) !"
 #endif
-  }
-}
+    }
+
+    //-------------------------------------------------------------------------------------------------
+    /// Returns ram and swap memory usage info into the MemInfo_t structure.
+
+    void memStats(MemoryStats &stats) {
+#if defined(__APPLE__)
+      darwinMemStats(stats);
+#elif defined(__linux__)
+      linuxMemStats(stats);
+#elif defined(_WIN32)
+      winMemStats(stats);
+#else
+#error "Unrecognized OS plateform (not windows, linux, OSX or unix) !"
+#endif
+    }
+
+    //-------------------------------------------------------------------------------------------------
+    /// Returns cpu and memory used by this process into the ProcInfo_t structure.
+
+    void procStats(ProcessStats &stats) {
+#if defined(__APPLE__)
+      darwinProcStats(stats);
+#elif defined(__linux__)
+      linuxProcStats(stats);
+#elif defined(_WIN32)
+      winProcStats(stats);
+#else
+#error "Unrecognized OS plateform (not windows, linux, OSX or unix) !"
+#endif
+    }
+
+    //-------------------------------------------------------------------------------------------------
+    /// Returns network and memory used by this process into the ProcInfo_t structure.
+
+    void netStats(NetworkStats &stats, dqm_int sampleTime) {
+#if defined(__APPLE__)
+      darwinNetStats(stats, sampleTime);
+#elif defined(__linux__)
+      linuxNetStats(stats, sampleTime);
+#elif defined(_WIN32)
+      winNetStats(stats, sampleTime);
+#else
+#error "Unrecognized OS plateform (not windows, linux, OSX or unix) !"
+#endif
+    }
+  } // namespace core
+} // namespace dqm4hep


### PR DESCRIPTION
BEGINRELEASENOTES
- Replace statistics (mem/cpu/network) implementation with implementation from [ROOT TSystem class](https://root.cern.ch/doc/master/classTSystem.html)
  - Better Handling of OS-dependent implementation
  - Had to copy/paste and adapt the implementation instead of just using it to tailor it to our needs.
  - Implements `cpuStats` + `networkStats` + partial implementation of `procStats` for `OSX` (missing cpu load)
  - Partial implementation of `procStats` for `Linux` (missing cpu load)
- Adapt/Add new exec to chec for theses stats:
  - Adapt executable to check for `memStats`
  - Add exec to check for `networkStats` and `cpuStats`
  - `procStats` are included in all these exec (i.e memory use from process is reported in `memStats`)   
  - Should I add an exec dedicated to check `procStats`?  
  - Windows implementation still missing
- Add `dqm_long` and `dqm_long_long` type

ENDRELEASENOTES

TODO: 
 - [x] Finish computation of CPU load from the process, both for osx and linux. 
 - [x] Finish linux implementation of NetStats (not computing rate for now) 
 - [ ] Add unit tests