### PR TITLE
Reference mechanism

### DIFF
--- a/source/include/dqm4hep/MonitorElementManager.h
+++ b/source/include/dqm4hep/MonitorElementManager.h
@@ -46,20 +46,22 @@ namespace dqm4hep {
 
   namespace core {
 
-    /** MonitorElementManager class
+    /** 
+     *  @brief  MonitorElementManager class
      */
     class MonitorElementManager {
       typedef std::shared_ptr<QualityTest> QualityTestPtr;
       typedef std::shared_ptr<QualityTestFactory> QualityTestFactoryPtr;
       typedef std::map<const std::string, QualityTestPtr> QualityTestMap;
       typedef std::map<const std::string, const QualityTestFactoryPtr> QualityTestFactoryMap;
-
     public:
-      /** Constructor
+      /** 
+       *  @brief  Constructor
        */
       MonitorElementManager();
 
-      /** Destructor
+      /** 
+       *  @brief  Destructor
        */
       ~MonitorElementManager();
 
@@ -67,39 +69,62 @@ namespace dqm4hep {
       // DIRECTORY INTERFACE //
       /////////////////////////
 
-      /** Go back to root directory
+      /** 
+       *  @brief  Go back to root directory
        */
       void cd();
 
-      /** Go to directory 'dirName'
+      /** 
+       *  @brief  Go to specific directory. 
+       *          If the directory name starts with with '/' the path is absolute 
+       *          and refers to the root directory, else it refers to the current directory  
+       *
+       *  @param  dirName the directory name to enter 
        */
       StatusCode cd(const std::string &dirName);
 
-      /** Create the directory 'dirName'
+      /** 
+       *  @brief  Create a directory
+       *          If the directory name starts with with '/' the path is absolute 
+       *          and refers to the root directory, else it refers to the current directory
+       *
+       *  @param  dirName the directory name
        */
       StatusCode mkdir(const std::string &dirName);
 
-      /** List the current directory content
-       */
       // void ls(bool recursive = false);
 
-      /** Get the current directory name
+      /** 
+       *  @brief  Get the current directory name
        */
       const std::string &pwd();
 
-      /** Get the current directory full name
+      /** 
+       *  @brief  Get the current directory full name (parents included)
        */
       const std::string &fullPwd();
 
-      /** Navigate backward in the directory structure
+      /** 
+       *  @brief  Navigate backward in the directory structure. 
+       *          Equivalent of 'cd ..' in a shell.
        */
       StatusCode goUp();
 
-      /** Remove the directory 'dirName'
+      /** 
+       *  @brief  Remove a directory
+       *          If the directory name starts with with '/' the path is absolute 
+       *          and refers to the root directory, else it refers to the current directory
+       *
+       *  @param  dirName the directory name 
        */
       StatusCode rmdir(const std::string &dirName);
 
-      /** Whether the directory exists
+      /** 
+       *  @brief  Whether the directory exists or not.
+       *          If the directory name starts with with '/' the path is absolute 
+       *          and refers to the root directory, else it refers to the current directory
+       *
+       *  @param  dirName the directory name
        */
       bool dirExists(const std::string &dirName) const;
 
@@ -108,96 +133,171 @@ namespace dqm4hep {
       // MONITOR ELEMENT INTERFACE //
       ///////////////////////////////
 
-      /** Add a monitor element from an external source.
-       *  WARNING : The ROOT object is owned by the framework.
-       *  The caller must NOT delete the object
+      /** 
+       *  @brief  Add a monitor element from an external source.
+       *          WARNING : The ROOT object is owned by the framework.
+       *          The caller must NOT delete the object
+       *
+       *  @param  path the monitor element path in the directory structure
+       *  @param  object the ROOT object to wrap in a monitor element
+       *  @param  monitorElement the monitor element pointer to receive
        */
       template <typename T>
-      StatusCode addMonitorElement(const std::string &path, TObject *pObject, std::shared_ptr<T> &monitorElement);
+      StatusCode addMonitorElement(const std::string &path, TObject *object, std::shared_ptr<T> &monitorElement);
 
-      /** Read TObject from file and add it to list.
-       *  The ROOT TObject is owned by the manager
+      /** 
+       *  @brief  Read TObject from file and add it to list.
+       *          The ROOT TObject is owned by the manager.
+       *          Note that this method might not be so efficient of called mutiple 
+       *          times as a TFile is opened and closed for each call
+       *
+       *  @param  fileName the ROOT file name to read
+       *  @param  path the path to the ROOT object to read and wrap in the monitor element
+       *  @param  name the name of the ROOT object
+       *  @param  monitorElement the monitor element to receive 
        */
       template <typename T>
       StatusCode readMonitorElement(const std::string &fileName, const std::string &path, const std::string &name,
                                     std::shared_ptr<T> &monitorElement);
 
-      /** Read TObject from file and add it to list.
-       *  The ROOT TObject is owned by the manager
+      /** 
+       *  @brief  Read TObject from file and add it to list.
+       *          The ROOT TObject is owned by the manager.
+       *
+       *  @param  pTFile the ROOT file instance to read the monitor element from
+       *  @param  path the TObject path in the file
+       *  @param  name the TObject name in the file
+       *  @param  monitorElement the monitor element instance to receive  
        */
       template <typename T>
       StatusCode readMonitorElement(TFile *pTFile, const std::string &path, const std::string &name,
                                     std::shared_ptr<T> &monitorElement);
 
-      /** Book a monitor element using the ROOT TClass facility.
-       *  The className is passed to TClass::GetClass() to get the corresponding
-       *  TClass object handler. Note that to allocate the TObject:
-       *    - the default constructor is used
-       *    - ROOT object is disabled so that object with same can be allocated safely memory leak
-       *  The resulting monitored TObject is owned by the manager
+      /** 
+       *  @brief  Book a monitor element using the ROOT TClass facility.
+       *          The className is passed to TClass::GetClass() to get the corresponding
+       *          TClass object handler. Note that to allocate the TObject:
+       *          - the default constructor is used
+       *          - the ROOT object is not referenced anywhere in the ROOT framework (see TObject::SetObjectStat and TH1::AddDirectory)
+       *          The resulting allocated TObject is thus fully owned by the manager
+       *
+       *  @param  className the ROOT class name (i.e "TGraph") to allocate
+       *  @param  path the path where to store the monitor element
+       *  @param  name the TObject name to set
+       *  @param  monitorElement the monitor element pointer to receive 
        */
       template <typename T>
       StatusCode bookMonitorElement(const std::string &className, const std::string &path, const std::string &name,
                                     std::shared_ptr<T> &monitorElement);
 
-      /** Add a monitor element from an external source.
-      *  WARNING : The ROOT object is NOT owned by the framework.
-      *  The caller must delete the object on termination
+      /** 
+       *  @brief  Handle and wrap the TObject in a monitor element.
+       *          WARNING : The ROOT object is NOT owned by the framework.
+       *          The caller must delete the object on termination.
+       *          You might use this function when the TObject is owned by another framework. 
+       *
+       *  @param  path the path where to store the monitor element
+       *  @param  pObject the input ROOT TObject to wrap
+       *  @param  monitorElement the monitor element pointer to receive 
        */
       template <typename T>
       StatusCode handleMonitorElement(const std::string &path, TObject *pObject, std::shared_ptr<T> &monitorElement);
-
-      /** Book a monitor element. The objectType must inherit TObject and have a ROOT dictionnary.
+      
+      /**
+       *  @brief  Create a custom ROOT object and wrap it into a monitor element. 
+       *          WARNING: The root class must inherit form TNamed in order to set the name and title corectly.
+       *          The created TObject is owned by the monitor element and must not be delete by users.
+       *          The allocation is performed using the ROOT object constructor possibly with arguments.
+       *          For histogram classes like TH1, TH2, TH3 and TProfile and daughters, use the bookHisto()
+       *          method instead. For scalar types (int, double, ...) use the bookScalar() method instead.
        *
+       *  Example:
+       *  @code
+       *  // Without arguments. Use the TGraph::TGraph() constructor
+       *  MonitorElement graphElement = nullptr;
+       *  mgr->bookObject<TGraph>("/MyDirectory", "SuperGraph", "A supeeeeer graph !", graphElement);
+       *  // With 42 points. Use the constructor Use the TGraph::TGraph(Int_t n) constructor
+       *  MonitorElement graphElement2 = nullptr;
+       *  mgr->bookObject<TGraph>("/MyDirectory", "SuperGraph2", "A supeeeeer graph with n points set!", graphElement2, 42);
+       *  @endcode
+       *  
+       *  @param  path the path where to store the monitor element
+       *  @param  name the monitor element name
+       *  @param  title the monitor element title
+       *  @param  monitorElement the monitor element pointer to receive
+       *  @param  args optional arguments to pass to the ROOT class constructor
        */
-      // template <typename T, typename ObjectType, typename... Args>
-      // StatusCode bookObject(const std::string &path, const std::string &name, std::shared_ptr<T> &monitorElement,
-      //                       AllocatorHelper<TObject, ObjectType, Args...> allocator, Args... args);
-                            
       template <typename ObjectType, typename T, typename... Args>
       StatusCode bookObject(const std::string &path, const std::string &name, const std::string &title, std::shared_ptr<T> &monitorElement, Args... args);
       
+      /**
+      *  @brief  Create a ROOT histogram and wrap it into a monitor element. 
+      *          The created histogram is owned by the monitor element and must not be delete by users.
+      *          The allocation is performed using the ROOT object constructor possibly with arguments.
+      *          For scalar types (int, double, ...) use the bookScalar() method instead. For other custom 
+      *          classes, use the bookObject() function. The last argument args are the arguments passed to 
+      *          the histogram constructor after the "name" and "title" arguments.
+      *
+      *  Example:
+      *  @code
+      *  // Use the constructor TH1F::TH1F(const char *name, const char *title, Int_t nBins, Double_t min, Double_t max)
+      *  MonitorElement histo1DElement = nullptr;
+      *  mgr->bookHisto<TH1F>("/MyDirectory", "SuperHisto", "A supeeeeer histo !", histo1DElement, 10, 0., 9.);
+      *  @endcode
+      *  
+      *  @param  path the path where to store the monitor element
+      *  @param  name the monitor element name
+      *  @param  title the monitor element title
+      *  @param  monitorElement the monitor element pointer to receive
+      *  @param  args optional arguments to pass to the histogram class after the name and title arguments
+       */
       template <typename HistoType, typename T, typename... Args>
       StatusCode bookHisto(const std::string &path, const std::string &name, const std::string &title, std::shared_ptr<T> &monitorElement, Args... args);
       
+      /**
+      *  @brief  Create a TScalarObject<ScalarType> of type T and wrap it into a monitor element. 
+      *          The created scalar object is owned by the monitor element and must not be delete by users.
+      *          The allocation is performed using the TScalarObject<ScalarType> constructor possibly with arguments.
+      *          For histogram classes like TH1, TH2, TH3 and TProfile and daughters, use the bookHisto()
+      *          method instead. For other custom classes, use the bookObject() function. The last argument 
+      *          args are the arguments passed to the TScalarObject<ScalarType> constructor.
+      *
+      *  Example:
+      *  @code
+      *  // Use the constructor TScalarObject<int>::TScalarObject<int>(int value)
+      *  MonitorElement intScalarElement = nullptr;
+      *  mgr->bookScalar<int>("/MyDirectory", "SuperScalar", "A supeeeeer scalar !", intScalarElement, 42);
+      *  @endcode
+      *  
+      *  @param  path the path where to store the monitor element
+      *  @param  name the monitor element name
+      *  @param  title the monitor element title
+      *  @param  monitorElement the monitor element pointer to receive
+      *  @param  args optional arguments to pass to the TScalarObject class
+       */
       template <typename ScalarType, typename T, typename... Args>
       StatusCode bookScalar(const std::string &path, const std::string &name, const std::string &title, std::shared_ptr<T> &monitorElement, Args... args);
-      
-      /**
-       *  @brief  Book a monitor element from the xml element
-       *  
-       *  @param  xmlElement the xml element to parse
-       *  @param  monitorelement the monitor element to receive
-       */
-      template <typename T>
-      StatusCode bookMonitorElement(TiXmlElement *xmlElement, std::shared_ptr<T> &monitorElement);
 
       /**
-       * @brief  Open root file, find reference object and attach it to the monitor element
+       *  @brief  Find reference file using the refId, look for a reference object and attach it to the monitor element.
+       *          The path and name of the reference must be the same as the monitor element
        *
-       * @param  pMonitorElement the monitor element to attach the reference
-       * @param  fileName        the root file name contaning the reference
+       *  @param  monitorElement the monitor element to attach the reference
+       *  @param  refId the reference file id
        */
       template <typename T>
-      StatusCode attachReference(std::shared_ptr<T> monitorElement, const std::string &fileName);
-      
+      StatusCode attachReference(std::shared_ptr<T> monitorElement, const std::string &refId);
+
       /**
-       *  @brief  Read monitor element described by the xml element from a root file
+       *  @brief  Find reference file using the refId, look for a reference object and attach it to the monitor element.
        *
-       *  @param  pXmlElement the xml element describing the objects to read
-       *  @param  readQTests whether to associate qtest to monitor elements
+       *  @param  monitorElement the monitor element to attach the reference
+       *  @param  refId the reference file id
+       *  @param  path the path to reference object in file
+       *  @param  name the name to reference object in file
        */
       template <typename T>
-      StatusCode readMonitorElements(TiXmlElement *const pXmlElement, bool readQTests = true);
-      
-      /**
-       *  @brief  Read monitor element described by the xml element from a root file
-       *
-       *  @param  pXmlElement the xml element describing the objects to read
-       *  @param  monitorelement the monitor element to receive
-       */
-      template <typename T>
-      StatusCode readMonitorElement(const std::string &fileName, TiXmlElement *const pXmlElement, std::shared_ptr<T> &monitorElement);
+      StatusCode attachReference(std::shared_ptr<T> monitorElement, const std::string &refId, const std::string &path, const std::string &name);
       
       /**
        *  @brief  Write all monitor elements in the storage to json
@@ -207,32 +307,136 @@ namespace dqm4hep {
       void monitorElementsToJson(json &object) const;
       
       /**
-       * 
+       *  @brief  Add a reference file under the specified id
+       *  
+       *  @param  refId the reference file id
+       *  @param  fname the reference file name
+       */
+      StatusCode addReferenceFile(const std::string &refId, const std::string &fname);
+      
+      /**
+       *  @brief  Iterate over the monitor element directory structure and call the user callback function.
+       *          The user function must have the form void f(std::shared_ptr<T> ptr), where T stand for the 
+       *          monitor element type, i.e MonitorElement.
+       *
+       *  Example:
+       *  @code
+       *  // Use a lambda function
+       *  mgr->iterate<MonitorElement>([](std::shared_ptr<MonitorElement> ptr){
+       *    std::cout << "Got element: type: " << ptr->type() << ", name: " << ptr->name() << std::endl;
+       *  });
+       *  @endcode
+       *
+       *  @param  function a user of the form void f(std::shared_ptr<T> ptr);
        */
       template <typename T, typename Function>
       void iterate(Function function);
       
+      /**
+       *  @brief  Dump the monitor element storage in the console.
+       *          Uses the macro dqm_info() for printing out
+       */
       void dumpStorage();
+      
+      /**
+       *  @brief  Parse the xml section describing:
+       *          - monitor element style in <style>
+       *          - reference files in <references>
+       *          - quality tests configuration in <qtests>
+       *          - monitor element to read/book in <monitorElements>
+       *          The template type T reference to the monitor element type to create
+       *          
+       * @param  xmlElement the input xml element
+       */
+      template <typename T>
+      StatusCode parseStorage(TiXmlElement *xmlElement);
+      
+    private:
+      /**
+       *  @brief  Read the style settings from the XML element
+       * 
+       *  @param  xmlElement the input XML element
+       */
+      StatusCode parseStyle(TiXmlElement *xmlElement);
+      
+      /**
+       *  @brief  Book a monitor element from the xml element
+       *  
+       *  @param  xmlElement the xml element to parse
+       *  @param  monitorelement the monitor element to receive
+       */
+      template <typename T>
+      StatusCode bookMonitorElement(TiXmlElement *xmlElement, std::shared_ptr<T> &monitorElement);
+      
+      /**
+       *  @brief  Read monitor element described by the xml element
+       *
+       *  @param  pXmlElement the xml element describing the monitor elements
+       */
+      template <typename T>
+      StatusCode parseMonitorElements(TiXmlElement *xmlElement);
+      
+      /**
+       *  @brief  Read monitor element described by the xml element from a root file
+       *
+       *  @param  pXmlElement the xml element describing the objects to read
+       *  @param  monitorelement the monitor element to receive
+       */
+      template <typename T>
+      StatusCode readMonitorElement(const std::string &fileName, TiXmlElement *xmlElement, std::shared_ptr<T> &monitorElement);
+      
+      /**
+       *  @brief  Read reference files from XML element
+       *          Feed a map of reference id (string) and reference file.
+       *          No reference association is made.
+       *  
+       *  @param  element the XML element to read
+       */
+      StatusCode parseReferences(TiXmlElement *xmlElement);
+      
+      /**
+       *  @brief  Read a single reference file the from XML element
+       *          Feed the map of reference id (string) -> reference file.
+       *          No reference association is made.
+       *  
+       *  @param  element the XML element to read
+       */
+      StatusCode parseReference(TiXmlElement *xmlElement);
+      
+      /** 
+       *  @brief  Create quality tests from the xml element
+       *
+       *  @param  xmlElement the XML element to parse
+       */
+      StatusCode parseQualityTests(TiXmlElement *xmlElement);   
 
     public:
-      ///////////////////////
-      // GETTERS INTERFACE //
-      ///////////////////////
-
-      /** Get all the monitor elements already booked by this module in all the directories
+      /** 
+       *  @brief  Get all the monitor elements already booked by this module in all the directories
+       *
+       *  @param  monitorElements the monitor elements to receive
        */
       template <typename T>
       void getMonitorElements(std::vector<std::shared_ptr<T>> &monitorElements) const;
 
-      /** Get the monitor element in the current directory (result by ptr reference)
+      /** 
+       *  @brief  Get the monitor element in the current directory (result by ptr reference)
+       *
+       *  @param  name the name of the monitor element
+       *  @param  monitorElement the monitor element to receive
        */
       template <typename T>
       StatusCode getMonitorElement(const std::string &name, std::shared_ptr<T> &monitorElement) const;
 
-      /** Get the monitor element in the given directory (result by ptr reference)
+      /** 
+       *  @brief  Get the monitor element in the given directory (result by ptr reference)
+       *
+       *  @param  path the path to the monitor element to find
+       *  @param  name the name of the monitor element to find
+       *  @param  monitorElement the monitor element to receive
        */
       template <typename T>
-      StatusCode getMonitorElement(const std::string &dirName, const std::string &name,
+      StatusCode getMonitorElement(const std::string &path, const std::string &name,
                                    std::shared_ptr<T> &monitorElement) const;
       
       /**
@@ -240,64 +444,131 @@ namespace dqm4hep {
        */
       void resetMonitorElements();
 
-      ////////////////////////
-      // DELETION INTERFACE //
-      ////////////////////////
-
-      /** Remove the monitor element
+      /** 
+       *  @brief  Remove a specific monitor element
+       *
+       *  @param  path the path to the monitor element
+       *  @param  name the name of the monitor element
        */
       StatusCode removeMonitorElement(const std::string &path, const std::string &name);
 
     public:
-      ////////////////////////////
-      // QUALITY TEST INTERFACE //
-      ////////////////////////////
-
-      /** Create quality tests from the xml element.
-       */
-      StatusCode createQualityTests(TiXmlElement *const pXmlElement);      
-      
-      /** Create a quality test from the xml element.
-       *  The xml element must contain the attribute 'type' and 'name'
+      /** 
+       *  @brief  Create a quality test from the xml element.
+       *          The xml element must contain the attribute 'type' and 'name'
+       *
+       *  @param  pXmlElement the XML element to parse
+       *  @param  warning the warning threshold level for this particular qtest (optional)
+       *  @param  error the error threshold level for this particular qtest (optional)
        */
       StatusCode createQualityTest(TiXmlElement *const pXmlElement, float warning = QualityTest::defaultWarningLimit(), float error = QualityTest::defaultErrorLimit());
 
-      /** Add a (already created) quality test to the monitor element
+      /** 
+       *  @brief  Attach an already created quality test to the monitor element
+       *
+       *  @param  path the path to the monitor element
+       *  @param  name the name of the monitor element
+       *  @param  qualityTestName the name of the quality test to attach
        */
       StatusCode addQualityTest(const std::string &path, const std::string &name, const std::string &qualityTestName);
 
-      /** Remove a quality test from the monitor element
+      /** 
+       *  @brief  Remove a quality test from the monitor element
+       *
+       *  @param  path the path to the monitor element
+       *  @param  name the name of the monitor element
+       *  @param  qualityTestName the name of the quality test to remove
        */
       StatusCode removeQualityTest(const std::string &path, const std::string &name,
                                    const std::string &qualityTestName);
 
       /**
+       *  @brief  Run all quality tests for all monitor elements and receive qtest reports
+       *
+       *  @param  reports the quality test reports to receive
        */
       StatusCode runQualityTests(QReportStorage &reports);
 
       /**
+       *  @brief  Run all quality tests attached to a particular monitor element
+       *
+       *  @param  path the path to the monitor element
+       *  @param  name the name of the monitor element
+       *  @param  reports the quality test reports to receive
        */
       StatusCode runQualityTests(const std::string &path, const std::string &name, QReportStorage &reports);
 
       /**
+       *  @brief  Run a particular quality test on one monitor element
+       *
+       *  @param  path the path to the monitor element
+       *  @param  name the name of the monitor element
+       *  @param  qualityTestName the name of the quality test to run
+       *  @param  reports the quality test reports to receive
        */
       StatusCode runQualityTest(const std::string &path, const std::string &name, const std::string &qualityTestName,
                                 QReportStorage &reports);
 
     private:
-      
+      /**
+       *  @brief  Check if the target class is compatible with the DQM4hep requirements.
+       *          See implementation for details
+       * 
+       *  @param  cls the ROOT TClass to check
+       */
       bool checkClass(TClass *cls);
+      
+      /**
+       *  @brief  Add a monitor element to the internal storage
+       *  
+       *  @param  path the path where to add this monitor element
+       *  @param  element the monitor element to add
+       */
       StatusCode addToStorage(const std::string &path, MonitorElementPtr element);
+      
+      /**
+       *  @brief  Create a monitor element and add it the internal storage
+       *  
+       *  @param  path the path where to add this monitor element
+       *  @param  pObject the ROOT object pointer to wrap in the monitor element
+       *  @param  monitorElement the monitor element to receive
+       *  @param  owner whether the monitor element should owns the ROOT object
+       */
       template <typename T>
       StatusCode createAndAddMonitorElement(const std::string &path, TObject *pObject, std::shared_ptr<T> &monitorElement, bool owner);
+
+      /**
+       *  @brief  Attach a reference, describe by the XML element, to the target monitor element
+       *  
+       *  @param  monitorElement the monitor element to which to attach the reference
+       *  @param  xmlElement the XML element from which to extract the reference
+       */
+      template <typename T>
+      StatusCode attachReference(std::shared_ptr<T> monitorElement, TiXmlElement *xmlElement);
       
+      /**
+       *  @brief  Performs the actual monitor element memory allocation.
+       *          The actual type T should inherit the MonitorElement class and provides
+       *          the same make_shared interface as the MonitorElement class (see MonitorElement.h)
+       *  
+       *  @param  args the arguments to forward to the allocator function
+       */
       template <typename T, typename... Args>
       std::shared_ptr<T> createMonitorElement(Args ...args);
       
-      /** Get the monitor element storage
+      /**
+       *  @brief  Get the monitor element storage
        */
       const Storage<MonitorElement> &getStorage() const;
       
+      /**
+       *  @brief  Perform a user action after having disabling any ROOT framework
+       *          memory handling such as the one implicitly done with TObject::GetObjectStat()
+       *          or with TH1::AddDirectoryStatus(). The ROOT memory handling is restored after 
+       *          the function has been called. The function must have the form 'void f()'.
+       *  
+       *  @param  function a user call back function
+       */
       template <typename T>
       void doROOTNotOwner(T function);
       
@@ -305,15 +576,24 @@ namespace dqm4hep {
       typedef std::shared_ptr<TObjectXMLAllocator> XMLAllocatorPtr;
       typedef std::map<MonitorElementPtr, QualityTestMap> MonitorElementToQTestMap;
       typedef std::map<std::string, XMLAllocatorPtr> XMLAllocatorMap;
+      typedef std::map<std::string, std::shared_ptr<TFile>> ReferenceMap;
 
-      Storage<MonitorElement> m_storage = {};
-      QualityTestFactoryMap m_qualityTestFactoryMap = {};
-      QualityTestMap m_qualityTestMap = {};
-      MonitorElementToQTestMap m_monitorElementToQTestMap = {};
+      /// The internal monitor element storage
+      Storage<MonitorElement>      m_storage = {};
+      /// The quality test factory map (plugins)
+      QualityTestFactoryMap        m_qualityTestFactoryMap = {};
+      /// The actual allocated quality test map
+      QualityTestMap               m_qualityTestMap = {};
+      /// The XML allocator map to create monitor elements from XML description
       XMLAllocatorMap              m_xmlAllocatorMap = {};
+      /// The default XML allocator function
       XMLAllocatorPtr              m_defaultXMLAllocator = {nullptr};
+      /// The current monitor element object style
       RootStyle                    m_objectStyle = {};
+      /// The current monitor element reference style
       RootStyle                    m_referenceStyle = {};
+      /// The map of reference ROOT files currently handled
+      ReferenceMap                 m_references = {};
     };
 
     //-------------------------------------------------------------------------------------------------
@@ -538,17 +818,32 @@ namespace dqm4hep {
     //-------------------------------------------------------------------------------------------------
 
     template <typename T>
-    inline StatusCode MonitorElementManager::attachReference(std::shared_ptr<T> monitorElement, const std::string &fileName) {
-      if (nullptr == monitorElement)
+    inline StatusCode MonitorElementManager::attachReference(std::shared_ptr<T> monitorElement, const std::string &refId) {
+      if (nullptr == monitorElement) {
         return STATUS_CODE_INVALID_PTR;
+      }
+      return attachReference(monitorElement, refId, monitorElement->path(), monitorElement->name());
+    }
+    
+    //-------------------------------------------------------------------------------------------------
 
-      Path fullName = monitorElement->path();
-      fullName += monitorElement->name();
+    template <typename T>
+    inline StatusCode MonitorElementManager::attachReference(std::shared_ptr<T> monitorElement, const std::string &refId, const std::string &path, const std::string &name) {
+      if (nullptr == monitorElement){
+        return STATUS_CODE_INVALID_PTR;
+      }
+      Path fullName = path;
+      fullName += name;
       dqm_debug("MonitorElementManager::attachReference: looking for element {0}", fullName.getPath());
+      
+      auto findIter = m_references.find(refId);
+      if(m_references.end() == findIter) {
+        dqm_error( "MonitorElementManager::attachReference: refId '{0}' not found !", refId );
+        return STATUS_CODE_NOT_FOUND;
+      }
+      auto rootFile = findIter->second;
 
-      std::unique_ptr<TFile> rootFile(new TFile(fileName.c_str(), "READ"));
-
-      const std::string queryPath = (monitorElement->path() == "/") ? monitorElement->name() : fullName.getPath();
+      const std::string queryPath = (path == "/") ? name : fullName.getPath();
       TObject *pTObject = nullptr;
       doROOTNotOwner([&](){
         auto local = rootFile->Get(queryPath.c_str());
@@ -568,38 +863,28 @@ namespace dqm4hep {
     //-------------------------------------------------------------------------------------------------
     
     template <typename T>
-    inline StatusCode MonitorElementManager::readMonitorElements(TiXmlElement *const pXmlElement, bool readQTests) {
-      if(nullptr == pXmlElement) {
-        dqm_error( "MonitorElementManager::readMonitorElements: Invalid xml element !" );
-        return STATUS_CODE_INVALID_PTR;
+    inline StatusCode MonitorElementManager::parseMonitorElements(TiXmlElement *xmlElement) {
+      if(nullptr == xmlElement) {
+        dqm_warning( "MonitorElementManager::readMonitorElements: No monitor elements to read from XML" );
+        return STATUS_CODE_SUCCESS;
       }
-      auto styleElement = pXmlElement->FirstChildElement("style");
-      if(nullptr != styleElement) {
-        std::string theme = RootStyle::Theme::DEFAULT;
-        RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::getAttribute(styleElement, 
-          "theme", theme));
-        RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, RootStyle::builtinStyle(theme, m_objectStyle, m_referenceStyle));
-        auto objectStyleElement = styleElement->FirstChildElement("object");
-        if(nullptr != objectStyleElement) {
-          RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, m_objectStyle.fromXml(TiXmlHandle(objectStyleElement)));
-        }
-        auto referenceStyleElement = styleElement->FirstChildElement("reference");
-        if(nullptr != referenceStyleElement) {
-          RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, m_referenceStyle.fromXml(TiXmlHandle(referenceStyleElement)));
-        }
-      }
-      else {
-        RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, RootStyle::builtinStyle(RootStyle::Theme::DEFAULT, m_objectStyle, m_referenceStyle));
-      }
-      for (TiXmlElement *child = pXmlElement->FirstChildElement(); child != nullptr; child = child->NextSiblingElement()) {
+      for (TiXmlElement *child = xmlElement->FirstChildElement(); child != nullptr; child = child->NextSiblingElement()) {
         std::shared_ptr<T> monitorElement;
         if(child->ValueStr() == "bookElement") {
           RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, bookMonitorElement<T>(child, monitorElement));
+          auto referenceElement = child->FirstChildElement("reference");
+          if(nullptr != referenceElement) {
+            RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, attachReference(monitorElement, referenceElement));
+          }
         }
         else if(child->ValueStr() == "fileElement") {
           std::string rootFile;
           RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::getAttribute(child, "file", rootFile));
           RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, readMonitorElement<T>(rootFile, child, monitorElement));
+          auto referenceElement = child->FirstChildElement("reference");
+          if(nullptr != referenceElement) {
+            RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, attachReference(monitorElement, referenceElement));
+          }
         }
         else if(child->ValueStr() == "file") {
           std::string rootFile;
@@ -608,14 +893,16 @@ namespace dqm4hep {
             // read sub-element
             std::shared_ptr<T> monitorElement2;
             RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, readMonitorElement<T>(rootFile, child2, monitorElement2));
-            // attach quality tests if option set
-            if(readQTests) {
-              for (TiXmlElement *qtest = child2->FirstChildElement("qtest"); qtest != nullptr; qtest = qtest->NextSiblingElement("qtest")) {
-                std::string qTestName;
-                RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::getAttribute(qtest, "name", qTestName));
-                RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, addQualityTest(monitorElement2->path(), monitorElement2->name(), qTestName));
-              }          
+            auto referenceElement = child2->FirstChildElement("reference");
+            if(nullptr != referenceElement) {
+              RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, attachReference(monitorElement2, referenceElement));
             }
+            // attach quality tests if option set
+            for (TiXmlElement *qtest = child2->FirstChildElement("qtest"); qtest != nullptr; qtest = qtest->NextSiblingElement("qtest")) {
+              std::string qTestName;
+              RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::getAttribute(qtest, "name", qTestName));
+              RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, addQualityTest(monitorElement2->path(), monitorElement2->name(), qTestName));
+            }          
           }
           continue;
         }
@@ -623,13 +910,11 @@ namespace dqm4hep {
           continue;
         }
         // attach quality tests if option set
-        if(readQTests) {
-          for (TiXmlElement *qtest = child->FirstChildElement("qtest"); qtest != nullptr; qtest = qtest->NextSiblingElement("qtest")) {
-            std::string qTestName;
-            RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::getAttribute(qtest, "name", qTestName));
-            RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, addQualityTest(monitorElement->path(), monitorElement->name(), qTestName));
-          }          
-        }
+        for (TiXmlElement *qtest = child->FirstChildElement("qtest"); qtest != nullptr; qtest = qtest->NextSiblingElement("qtest")) {
+          std::string qTestName;
+          RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::getAttribute(qtest, "name", qTestName));
+          RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, addQualityTest(monitorElement->path(), monitorElement->name(), qTestName));
+        }          
       }
       return STATUS_CODE_SUCCESS;
     }
@@ -667,6 +952,59 @@ namespace dqm4hep {
         auto castPointer = std::dynamic_pointer_cast<T>(monitorElement);
         return function(castPointer);
       });
+    }
+    
+    //-------------------------------------------------------------------------------------------------
+    
+    template <typename T>
+    StatusCode MonitorElementManager::attachReference(std::shared_ptr<T> monitorElement, TiXmlElement *element) {
+      std::string refId, path, name;
+      RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::getAttribute(element, "id", refId));
+      auto pathCode = XmlHelper::getAttribute(element, "path", path);
+      if(STATUS_CODE_NOT_FOUND == pathCode) {
+        path = monitorElement->path();
+      }
+      else if(STATUS_CODE_SUCCESS != pathCode) {
+        return pathCode;
+      }
+      auto nameCode = XmlHelper::getAttribute(element, "name", name);
+      if(STATUS_CODE_NOT_FOUND == nameCode) {
+        name = monitorElement->name();
+      }
+      else if(STATUS_CODE_SUCCESS != nameCode) {
+        return nameCode;
+      }      
+      RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, attachReference(monitorElement, refId, path, name));
+      return STATUS_CODE_SUCCESS;
+    }
+    
+    //-------------------------------------------------------------------------------------------------
+    
+    template <typename T>
+    StatusCode MonitorElementManager::parseStorage(TiXmlElement *xmlElement) {
+      if(nullptr == xmlElement) {
+        dqm_error( "MonitorElementManager::parseStorage: Got nullptr as input xml element !" );
+        return STATUS_CODE_INVALID_PTR;
+      }
+      // parse the monitor element style
+      auto styleElement = xmlElement->FirstChildElement("style");
+      RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, parseStyle(styleElement));
+      // parse the references
+      auto referencesElement = xmlElement->FirstChildElement("references");
+      if(nullptr != referencesElement) {
+        RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, parseReferences(referencesElement));
+      }
+      // parse the quality tests
+      auto qtestsElement = xmlElement->FirstChildElement("qtests");
+      if(nullptr != qtestsElement) {
+        RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, parseQualityTests(qtestsElement));        
+      }
+      // parse the monitor elements
+      auto monitorElementsElement = xmlElement->FirstChildElement("monitorElements");
+      if(nullptr != monitorElementsElement) {
+        RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, parseMonitorElements<T>(monitorElementsElement));        
+      }
+      return STATUS_CODE_SUCCESS;
     }
     
   }

--- a/source/main/dqm4hep-run-qtests.cc
+++ b/source/main/dqm4hep-run-qtests.cc
@@ -213,15 +213,12 @@ int main(int argc, char *argv[]) {
     TiXmlDocument &document(parser.document());
     StringMap constants;
     TiXmlElement *rootElement = document.RootElement();
-    TiXmlElement *qtestsElement = rootElement->FirstChildElement("qtests");
-    TiXmlElement *mesElement = rootElement->FirstChildElement("monitorElements");
-    
+    TiXmlElement *storageElement = rootElement->FirstChildElement("storage");
     std::unique_ptr<MonitorElementManager> monitorElementMgr(new MonitorElementManager());
     
     // create, configure and run quality tests
     QReportStorage reportStorage;
-    THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, monitorElementMgr->createQualityTests(qtestsElement));
-    THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, monitorElementMgr->readMonitorElements<MonitorElement>(mesElement, true));
+    THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, monitorElementMgr->parseStorage<MonitorElement>(storageElement));
     THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, monitorElementMgr->runQualityTests(reportStorage));
     
     const unsigned int qualityExit(qualityExitMap.find(qualityExitArg.getValue())->second);

--- a/tests/test_samples.xml
+++ b/tests/test_samples.xml
@@ -5,152 +5,142 @@
     <constant name="TGraphDirectory">/TGraphs</constant>
   </constants>
 
-    <!-- PropertyWithinExpectedTest qtests -->
+  <storage>
+    <!-- Use the same root file as input file for reference -->
+    <references>
+      <file id="ref" name="test_samples.root"/>
+    </references>
+    <!-- Quality tests config  -->
     <qtests>
-
       <qtest type="PropertyWithinExpectedTest" name="MeanAround10Long">
         <parameter name="ExpectedValue" value="10"/>
         <parameter name="DeviationLower" value="8"/>
         <parameter name="DeviationUpper" value="12"/>
-	<parameter name="Property"> Mean </parameter>
+        <parameter name="Property"> Mean </parameter>
       </qtest>
-
       <qtest type="PropertyWithinExpectedTest" name="MeanAround10Short">
         <parameter name="ExpectedValue" value="10"/>
         <parameter name="DeviationLower" value="9.5"/>
         <parameter name="DeviationUpper" value="10.5"/>
-	<parameter name="Property"> Mean </parameter>
+        <parameter name="Property"> Mean </parameter>
       </qtest>
-
       <qtest type="PropertyWithinExpectedTest" name="MeanBelow12">
-        <parameter name="DeviationUpper" value="12" />
-	<parameter name="Property"> Mean </parameter>
-	<parameter name="Method"> LowerThan </parameter>
+        <parameter name="DeviationUpper" value="12"/>
+        <parameter name="Property"> Mean </parameter>
+        <parameter name="Method"> LowerThan </parameter>
       </qtest>
-
       <qtest type="PropertyWithinExpectedTest" name="MeanAbove8">
-        <parameter name="DeviationLower" value="8" />
-	<parameter name="Property"> Mean </parameter>
-	<parameter name="Method"> HigherThan </parameter>
+        <parameter name="DeviationLower" value="8"/>
+        <parameter name="Property"> Mean </parameter>
+        <parameter name="Method"> HigherThan </parameter>
       </qtest>
-
       <qtest type="PropertyWithinExpectedTest" name="Mean90Around10Short">
         <parameter name="ExpectedValue" value="10"/>
         <parameter name="DeviationLower" value="9.5"/>
         <parameter name="DeviationUpper" value="10.5"/>
-	<parameter name="Property"> Mean90 </parameter>
+        <parameter name="Property"> Mean90 </parameter>
       </qtest>
-
       <qtest type="PropertyWithinExpectedTest" name="MeanAround15Short">
         <parameter name="ExpectedValue" value="15"/>
         <parameter name="DeviationLower" value="14.5"/>
         <parameter name="DeviationUpper" value="15.5"/>
-	<parameter name="Property"> Mean </parameter>
+        <parameter name="Property"> Mean </parameter>
       </qtest>
-
       <qtest type="PropertyWithinExpectedTest" name="RMSAround2Long">
         <parameter name="ExpectedValue" value="2"/>
         <parameter name="DeviationLower" value="0"/>
         <parameter name="DeviationUpper" value="4"/>
-	<parameter name="Property"> RMS </parameter>
+        <parameter name="Property"> RMS </parameter>
       </qtest>
-
       <qtest type="PropertyWithinExpectedTest" name="RMS90Around2Long">
         <parameter name="ExpectedValue" value="2"/>
         <parameter name="DeviationLower" value="0"/>
         <parameter name="DeviationUpper" value="4"/>
-	<parameter name="Property"> RMS90 </parameter>
+        <parameter name="Property"> RMS90 </parameter>
       </qtest>
-
       <qtest type="PropertyWithinExpectedTest" name="MedianAround10Long">
         <parameter name="ExpectedValue" value="10"/>
         <parameter name="DeviationLower" value="8"/>
         <parameter name="DeviationUpper" value="12"/>
-	<parameter name="Property"> Median </parameter>
+        <parameter name="Property"> Median </parameter>
       </qtest>
-
       <qtest type="PropertyWithinExpectedTest" name="MedianAround10Short" error="0.5" warning="0.75">
         <parameter name="ExpectedValue" value="10"/>
         <parameter name="DeviationLower" value="9"/>
         <parameter name="DeviationUpper" value="11"/>
-	<parameter name="Property"> Median  </parameter>
+        <parameter name="Property"> Median </parameter>
       </qtest>
-
-      <qtest type="PropertyWithinExpectedTest" name="TGraphMeanAround0" >
-	<parameter name="ExpectedValue" value="0"/>
-	<parameter name="DeviationLower" value="-2"/>
-	<parameter name="DeviationUpper" value="2"/>
-	<parameter name="Property"> Mean </parameter>
+      <qtest type="PropertyWithinExpectedTest" name="TGraphMeanAround0">
+        <parameter name="ExpectedValue" value="0"/>
+        <parameter name="DeviationLower" value="-2"/>
+        <parameter name="DeviationUpper" value="2"/>
+        <parameter name="Property"> Mean </parameter>
       </qtest>
-
       <qtest type="PropertyWithinExpectedTest" name="TGraphMeanAround3">
-	<parameter name="ExpectedValue" value="3"/>
-	<parameter name="DeviationLower" value="1"/>
-	<parameter name="DeviationUpper" value="4"/>
-	<parameter name="Property"> Mean </parameter>
+        <parameter name="ExpectedValue" value="3"/>
+        <parameter name="DeviationLower" value="1"/>
+        <parameter name="DeviationUpper" value="4"/>
+        <parameter name="Property"> Mean </parameter>
       </qtest>
-
-      <qtest type="PropertyWithinExpectedTest" name="TGraphRMSAround0" >
-	<parameter name="ExpectedValue" value="0"/>
-	<parameter name="DeviationLower" value="-2"/>
-	<parameter name="DeviationUpper" value="2"/>
-	<parameter name="Property"> RMS </parameter>
+      <qtest type="PropertyWithinExpectedTest" name="TGraphRMSAround0">
+        <parameter name="ExpectedValue" value="0"/>
+        <parameter name="DeviationLower" value="-2"/>
+        <parameter name="DeviationUpper" value="2"/>
+        <parameter name="Property"> RMS </parameter>
       </qtest>
-
-      <qtest type="PropertyWithinExpectedTest" name="TGraphMean90Around0" >
-	<parameter name="ExpectedValue" value="0"/>
-	<parameter name="DeviationLower" value="-2"/>
-	<parameter name="DeviationUpper" value="2"/>
-	<parameter name="Property"> Mean90 </parameter>
+      <qtest type="PropertyWithinExpectedTest" name="TGraphMean90Around0">
+        <parameter name="ExpectedValue" value="0"/>
+        <parameter name="DeviationLower" value="-2"/>
+        <parameter name="DeviationUpper" value="2"/>
+        <parameter name="Property"> Mean90 </parameter>
       </qtest>
-
-      <qtest type="PropertyWithinExpectedTest" name="TGraphRMS90Around0" >
-	<parameter name="ExpectedValue" value="0"/>
-	<parameter name="DeviationLower" value="-2"/>
-	<parameter name="DeviationUpper" value="2"/>
-	<parameter name="Property"> RMS90 </parameter>
+      <qtest type="PropertyWithinExpectedTest" name="TGraphRMS90Around0">
+        <parameter name="ExpectedValue" value="0"/>
+        <parameter name="DeviationLower" value="-2"/>
+        <parameter name="DeviationUpper" value="2"/>
+        <parameter name="Property"> RMS90 </parameter>
       </qtest>
-
-      <qtest type="PropertyWithinExpectedTest" name="TGraphMedianAround0.2" error="0.5" >
-	<parameter name="ExpectedValue" value="0.2"/>
-	<parameter name="DeviationLower" value="0.1"/>
-	<parameter name="DeviationUpper" value="0.3"/>
-	<parameter name="Property"> Median </parameter>
+      <qtest type="PropertyWithinExpectedTest" name="TGraphMedianAround0.2" error="0.5">
+        <parameter name="ExpectedValue" value="0.2"/>
+        <parameter name="DeviationLower" value="0.1"/>
+        <parameter name="DeviationUpper" value="0.3"/>
+        <parameter name="Property"> Median </parameter>
       </qtest>
-
+      <qtest type="ExactRefCompareTest" name="ExactRef"/>
     </qtests>
 
     <!-- All monitor elements and qtests to process -->
     <monitorElements>
       <file name="test_samples.root">
         <fileElement path="${GaussiansDirectory}" name="Gaus_Mean10_RMS2">
-          <qtest name="MeanAround10Long" />
-	  <qtest name="Mean90Around10Short" />
-	  <qtest name="RMSAround2Long" />
-	  <qtest name="MedianAround10Short" />
-	  <qtest name="MeanAbove8" />
-	  <qtest name="MeanBelow12" />
+          <qtest name="MeanAround10Long"/>
+          <qtest name="Mean90Around10Short"/>
+          <qtest name="RMSAround2Long"/>
+          <qtest name="MedianAround10Short"/>
+          <qtest name="MeanAbove8"/>
+          <qtest name="MeanBelow12"/>
         </fileElement>
         <fileElement path="${GaussiansDirectory}" name="Gaus_Mean10_RMS2_bck">
-          <qtest name="MeanAround10Short" />
+          <reference id="ref"/>
+          <qtest name="MeanAround10Short"/>
+          <qtest name="ExactRef"/>
         </fileElement>
         <fileElement path="${GaussiansDirectory}" name="DblGaus_Mean15_RMS2_RMS5">
-          <qtest name="MeanAround15Short" />
+          <qtest name="MeanAround15Short"/>
         </fileElement>
-	<fileElement path="${GaussiansDirectory}" name="Gaus_Mean8_RMS2">
-	  <qtest name="MedianAround10Short" />
-	</fileElement>
-
-	<fileElement path="${TGraphDirectory}" name="Gaus_Mean0_RMS2">
-	  <qtest name="TGraphMeanAround0" />
-	  <qtest name="TGraphMeanAround3" />
-	  <qtest name="TGraphMean90Around0" />
-	  <qtest name="TGraphRMSAround0" />
-	  <qtest name="TGraphRMS90Around0" />
-	  <qtest name="TGraphMedianAround0.2" />
-	</fileElement>
-	
+        <fileElement path="${GaussiansDirectory}" name="Gaus_Mean8_RMS2">
+          <qtest name="MedianAround10Short"/>
+        </fileElement>
+        <fileElement path="${TGraphDirectory}" name="Gaus_Mean0_RMS2">
+          <qtest name="TGraphMeanAround0"/>
+          <qtest name="TGraphMeanAround3"/>
+          <qtest name="TGraphMean90Around0"/>
+          <qtest name="TGraphRMSAround0"/>
+          <qtest name="TGraphRMS90Around0"/>
+          <qtest name="TGraphMedianAround0.2"/>
+        </fileElement>
       </file>
     </monitorElements>
+  </storage>
 
 </dqm4hep>


### PR DESCRIPTION

BEGINRELEASENOTES
- Fully implemented the reference mechanism
    - Can specify in XML file a set of reference file
    - Can attach any reference object to a monitor element
- MonitorElementManager class
    - Added proper Doxygen documentation
- XML parsing for monitor elements
    - Moved the `<style>`, `<monitorElements>`, `<qtests>` and `<references>` element in a global one called `<storage>`
- Quality test unit test
    - Added ExactRef comparison qtest using the newly introduced reference mechanism

ENDRELEASENOTES