### PR TITLE
Archiver is back

### DIFF
--- a/source/include/dqm4hep/Archiver.h
+++ b/source/include/dqm4hep/Archiver.h
@@ -58,10 +58,10 @@ namespace dqm4hep {
        *          See open() for argument explanation
        *
        *  @param  archiveFileName the root file name
-       *  @param  openingMode the ROOT file opening mode
+       *  @param  opMode the ROOT file opening mode
        *  @param  overwrite whether to allow to overwrite previous archive
        */
-      Archiver(const std::string &fname, const std::string &openingMode = "RECREATE", bool overwrite = false);
+      Archiver(const std::string &fname, const std::string &opMode = "RECREATE", bool overwrite = false);
 
       /** 
        *  @brief  Destructor
@@ -76,10 +76,10 @@ namespace dqm4hep {
        *          is unique and no archive is overwritten
        *
        *  @param  fname the ROOT file name to open
-       *  @param  openingMode the ROOT file opening mode
+       *  @param  opMode the ROOT file opening mode
        *  @param  overwrite whether to allow for overwrite
        */
-      StatusCode open(const std::string &fname, const std::string &openingMode = "RECREATE",
+      StatusCode open(const std::string &fname, const std::string &opMode = "RECREATE",
                       bool overwrite = true);
 
       /** 

--- a/source/include/dqm4hep/MonitorElementManager.h
+++ b/source/include/dqm4hep/MonitorElementManager.h
@@ -41,6 +41,7 @@
 #include <dqm4hep/RootHeaders.h>
 #include <dqm4hep/Directory.h>
 #include <dqm4hep/RootStyle.h>
+#include <dqm4hep/Archiver.h>
 
 namespace dqm4hep {
 
@@ -350,6 +351,13 @@ namespace dqm4hep {
        */
       template <typename T>
       StatusCode parseStorage(TiXmlElement *xmlElement);
+      
+      /**
+       *  @brief  Archive the current monitor element content in a root file
+       *
+       *  @param  archiver the archiver performing the write operation
+       */
+      StatusCode archive(Archiver &archiver);
       
     private:
       /**

--- a/source/src/Archiver.cc
+++ b/source/src/Archiver.cc
@@ -41,8 +41,8 @@ namespace dqm4hep {
 
   namespace core {
 
-    Archiver::Archiver(const std::string &archiveFileName, const std::string &openingMode, bool overwrite) {
-      THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->open(archiveFileName, openingMode, overwrite));
+    Archiver::Archiver(const std::string &archiveFileName, const std::string &opMode, bool overwrite) {
+      THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->open(archiveFileName, opMode, overwrite));
     }
 
     //-------------------------------------------------------------------------------------------------
@@ -54,7 +54,7 @@ namespace dqm4hep {
 
     //-------------------------------------------------------------------------------------------------
 
-    StatusCode Archiver::open(const std::string &fname, const std::string &openingMode, bool overwrite) {
+    StatusCode Archiver::open(const std::string &fname, const std::string &opMode, bool overwrite) {
       // if already open write the archive if not done
       // and close it before to re-open
       if (isOpened()) {
@@ -83,9 +83,9 @@ namespace dqm4hep {
       else {
         m_fileName = fname;
       }
-      m_openingMode = openingMode;
+      m_openingMode = opMode;
       dqm_info("Archiver::open: Opening archive {0}", m_fileName);
-      m_file.reset(new TFile(m_fileName.c_str(), openingMode.c_str()));
+      m_file.reset(new TFile(m_fileName.c_str(), m_openingMode.c_str()));
       if (nullptr == m_file) {
         dqm_error("Archiver::open: Couldn't open archive '{0}' !", m_fileName);
         return STATUS_CODE_FAILURE;

--- a/source/src/MonitorElementManager.cc
+++ b/source/src/MonitorElementManager.cc
@@ -467,6 +467,12 @@ namespace dqm4hep {
       return STATUS_CODE_SUCCESS;
     }
     
+    //-------------------------------------------------------------------------------------------------
+    
+    StatusCode MonitorElementManager::archive(Archiver &archiver) {
+      return archiver.archiveWithReferences(m_storage, "", "_ref");
+    }
+    
   }
   
 }

--- a/tests/test_samples.xml
+++ b/tests/test_samples.xml
@@ -6,6 +6,7 @@
   </constants>
 
   <storage>
+    <style theme="polar"/>
     <!-- Use the same root file as input file for reference -->
     <references>
       <file id="ref" name="test_samples.root"/>


### PR DESCRIPTION
BEGINRELEASENOTES
- Archiver class
   - Added proper Doxygen documentation
   - Added possiblity to archive references along with monitor objects by adding a suffix (default is "_ref")
- MonitorElementManager class
   - Added method `archive()` to archive current storage content with references
- QTest runner
   - Added `--root-output` or `-o` argument to allow for archiving monitor elements and references in a root file after processing
   - Modified argument name for qreport output file to `--qreport-output` or `-q` 
- Set theme style to `polar` in test_samples.xml 

ENDRELEASENOTES