### PR TITLE
Xml parser no nested constants

### DIFF
--- a/source/include/dqm4hep/XMLParser.h
+++ b/source/include/dqm4hep/XMLParser.h
@@ -165,7 +165,7 @@ namespace dqm4hep {
                                std::string &relativeFileName);
 
       // constants related functions
-      void readConstants(TiXmlNode *node);
+      void readConstants();
       void replaceAllConstants();
       void readConstantsSection(TiXmlElement *constants);
       void resolveConstantsInElement(TiXmlElement *element);

--- a/source/include/dqm4hep/XMLParser.h
+++ b/source/include/dqm4hep/XMLParser.h
@@ -149,6 +149,18 @@ namespace dqm4hep {
        *  @brief  Whether to allow the use of environment variable while resolving constants
        */
       bool allowEnvVariables() const;
+      
+      /**
+       *  @brief  Set whether to process XML for loop elements
+       *
+       *  @param  process whether to process for loops
+       */
+      void setProcessForLoops(bool process);
+
+      /**
+       *  @brief  Whether to process XML for loop elements
+       */
+      bool processForLoops() const;
 
     private:
       // parsing functions
@@ -188,6 +200,7 @@ namespace dqm4hep {
       bool m_processConstants = {true};    ///< Whether to process constants elements
       bool m_processDatabase = {true};     ///< Whether to process database elements
       bool m_allowEnvVariables = {true};   ///< Whether to allow the use of environment variables
+      bool m_processForLoops = {true};     ///< Whether to process for loops
       std::string m_fileName = {""};       ///< The file name of the last parsed file
       TiXmlDocument m_document = {};       ///< The xml document
       StringMap m_constants = {};          ///< The constants map

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -79,11 +79,13 @@ namespace dqm4hep {
         }
       }
       
-      try {
-        this->resolveForLoops();
-      } catch (StatusCodeException &exception) {
-        dqm_error("XMLParser::parse(): fail to resolve for loops, {0}", exception.toString());
-        throw exception;
+      if(this->processForLoops()) {
+        try {
+          this->resolveForLoops();
+        } catch (StatusCodeException &exception) {
+          dqm_error("XMLParser::parse(): fail to resolve for loops, {0}", exception.toString());
+          throw exception;
+        }        
       }
     }
 
@@ -178,6 +180,18 @@ namespace dqm4hep {
 
     bool XMLParser::allowEnvVariables() const {
       return m_allowEnvVariables;
+    }
+    
+    //----------------------------------------------------------------------------------------------------
+    
+    void XMLParser::setProcessForLoops(bool process) {
+      m_processForLoops = process;
+    }
+
+    //----------------------------------------------------------------------------------------------------
+
+    bool XMLParser::processForLoops() const {
+      return m_processForLoops;
     }
 
     //----------------------------------------------------------------------------------------------------

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -361,8 +361,6 @@ namespace dqm4hep {
         if (element->Value() == std::string("constants")) {
           this->readConstantsSection(element);
         }
-        // else
-        //   this->readConstants(element);
       }
     }
 

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -126,6 +126,9 @@ namespace dqm4hep {
 
     void XMLParser::setProcessIncludes(bool process) {
       m_processIncludes = process;
+      if(not m_processIncludes) {
+        dqm_warning( "XMLParser: <include> elements will not be processed !" );
+      }
     }
 
     //----------------------------------------------------------------------------------------------------
@@ -138,6 +141,9 @@ namespace dqm4hep {
 
     void XMLParser::setAllowNestedIncludes(bool allow) {
       m_allowNestedIncludes = allow;
+      if(not m_allowNestedIncludes) {
+        dqm_warning( "XMLParser: nested <include> elements will not be processed !" );
+      }
     }
 
     //----------------------------------------------------------------------------------------------------
@@ -150,6 +156,9 @@ namespace dqm4hep {
 
     void XMLParser::setProcessConstants(bool process) {
       m_processConstants = process;
+      if(not m_processConstants) {
+        dqm_warning( "XMLParser: constants will not be parsed !" );
+      }
     }
 
     //----------------------------------------------------------------------------------------------------
@@ -162,6 +171,9 @@ namespace dqm4hep {
 
     void XMLParser::setProcessDatabase(bool process) {
       m_processDatabase = process;
+      if(not m_processDatabase) {
+        dqm_warning( "XMLParser: no database will be used for parsing !" );
+      }
     }
 
     //----------------------------------------------------------------------------------------------------
@@ -174,6 +186,9 @@ namespace dqm4hep {
 
     void XMLParser::setAllowEnvVariables(bool allow) {
       m_allowEnvVariables = allow;
+      if(not m_allowEnvVariables) {
+        dqm_warning( "XMLParser: environment variables will not be replaced !" );
+      }
     }
 
     //----------------------------------------------------------------------------------------------------
@@ -186,6 +201,9 @@ namespace dqm4hep {
     
     void XMLParser::setProcessForLoops(bool process) {
       m_processForLoops = process;
+      if(not m_processForLoops) {
+        dqm_warning( "XMLParser: <for> for loop elements will not be processed !" );
+      }
     }
 
     //----------------------------------------------------------------------------------------------------

--- a/source/src/XMLParser.cc
+++ b/source/src/XMLParser.cc
@@ -200,7 +200,7 @@ namespace dqm4hep {
     //----------------------------------------------------------------------------------------------------
 
     void XMLParser::resolveConstants() {
-      this->readConstants(&m_document);
+      this->readConstants();
       this->replaceAllConstants();
     }
 
@@ -341,13 +341,14 @@ namespace dqm4hep {
 
     //----------------------------------------------------------------------------------------------------
 
-    void XMLParser::readConstants(TiXmlNode *node) {
-      for (TiXmlElement *element = node->FirstChildElement(); element != nullptr;
-           element = element->NextSiblingElement()) {
-        if (element->Value() == std::string("constants"))
+    void XMLParser::readConstants() {
+      TiXmlElement *root = document().RootElement();
+      for (TiXmlElement *element = root->FirstChildElement(); element != nullptr; element = element->NextSiblingElement()) {
+        if (element->Value() == std::string("constants")) {
           this->readConstantsSection(element);
-        else
-          this->readConstants(element);
+        }
+        // else
+        //   this->readConstants(element);
       }
     }
 

--- a/source/tests/test-xmlparser.cc
+++ b/source/tests/test-xmlparser.cc
@@ -74,8 +74,14 @@ int main(int /*argc*/, char *argv[]) {
   int age = parser.constantAs<int>("age", 0);
   assert_test(age == 32);
 
+  std::string incVar1 = parser.constantAs<std::string>("incVar1", "");
+  assert_test(incVar1 == "toto");
+  
+  std::string incVar2 = parser.constantAs<std::string>("incVar2", "");
+  assert_test(incVar2 == "tata");
+
   std::string badguy = parser.constantAs<std::string>("badguy", "");
-  assert_test(badguy == "dracula");
+  assert_test(badguy.empty());
 
   std::string notFound = parser.constantAs<std::string>("bibou", "missing");
   assert_test(notFound == "missing");

--- a/tests/test_xmlparser_include.xml
+++ b/tests/test_xmlparser_include.xml
@@ -1,4 +1,9 @@
 <dqm4hep>
+
+  <constants>
+    <constant name="incVar1" value="toto"/>
+    <constant name="incVar2" value="tata"/>
+  </constants>
   
   <nested>
     <constants>


### PR DESCRIPTION

BEGINRELEASENOTES
- Disabled nested constants definition. Snippet like:
```xml
<dqm4hep>
  <dummy>
    <constants>
      <constant name="aName" value="aValue"/>
    </constants>
  </dummy>
</dqm4hep>
```
are no longer processed/valid. Only `<constants>` sections contained in the root element will be processed

ENDRELEASENOTES