### PR TITLE
Fix archiver selector

### DIFF
--- a/source/src/Archiver.cc
+++ b/source/src/Archiver.cc
@@ -233,6 +233,9 @@ namespace dqm4hep {
 
     ArchiverSelector::ArchiverSelector() {
       m_function = [this](MonitorElementPtr element)->bool{
+        if(m_selectorFunctions.empty()) {
+          return true;
+        }
         for(auto &selector : m_selectorFunctions) {
           if(selector(element)) {
             dqm_debug( "Archiving element path: {0}, name: {1} ...", element->path(), element->name() );


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix bug in archiver selector. 
    - Fix: if no selector is added to list, return true which the default behavior in the Archiver function

ENDRELEASENOTES